### PR TITLE
Fix whitespace handling in endpoint regex

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -51,10 +51,21 @@ const rawRegex = `
   (?:"|')
 
 `
-
 const contextDelimiter = "\n"
 
-var endpointRegex = regexp.MustCompile(rawRegex)
+var endpointRegex = regexp.MustCompile(compactPattern(rawRegex))
+
+func compactPattern(pattern string) string {
+	var builder strings.Builder
+	for _, line := range strings.Split(pattern, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		builder.WriteString(trimmed)
+	}
+	return builder.String()
+}
 
 // EndpointRegex returns the compiled regex used to detect endpoints.
 func EndpointRegex() *regexp.Regexp {


### PR DESCRIPTION
## Summary
- strip formatting whitespace from the endpoint pattern before compiling it so matches are found again

## Testing
- go test ./...
- go run . -i /tmp/sample.js

------
https://chatgpt.com/codex/tasks/task_e_68e22b11e7ec83298a39a911e2ba600e