### PR TITLE
Improve CLI output clarity for file inputs

### DIFF
--- a/internal/output/cli.go
+++ b/internal/output/cli.go
@@ -7,8 +7,18 @@ import (
 )
 
 // PrintCLI prints endpoints to stdout in CLI mode.
-func PrintCLI(endpoints []model.Endpoint) {
-	for _, ep := range endpoints {
-		fmt.Println(ep.Link)
+func PrintCLI(resource string, endpoints []model.Endpoint) {
+	fmt.Printf("File: %s\n", resource)
+
+	if len(endpoints) == 0 {
+		fmt.Println("  No endpoints were found.")
+		fmt.Println()
+		return
 	}
+
+	for _, ep := range endpoints {
+		fmt.Printf("  %s\n", ep.Link)
+	}
+
+	fmt.Println()
 }

--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func processDomain(cfg config.Config, baseResource string, endpoints []model.End
 
 func render(mode output.Mode, resource string, endpoints []model.Endpoint, builder *strings.Builder) {
 	if mode == output.ModeCLI {
-		output.PrintCLI(endpoints)
+		output.PrintCLI(resource, endpoints)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- print the resource name when outputting CLI results
- show a helpful message when no endpoints are found for a processed resource

## Testing
- go build ./...


------
https://chatgpt.com/codex/tasks/task_e_68e22b11e7ec83298a39a911e2ba600e