### PR TITLE
Add unit tests for input, network, and parser packages

### DIFF
--- a/internal/input/input_test.go
+++ b/internal/input/input_test.go
@@ -1,0 +1,127 @@
+package input
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/example/GoLinkfinderEVO/internal/config"
+)
+
+func TestResolveTargetsHTTP(t *testing.T) {
+	cfg := config.Config{Input: "https://example.com/app.js"}
+	targets, err := ResolveTargets(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target, got %d", len(targets))
+	}
+	if targets[0].URL != cfg.Input {
+		t.Fatalf("expected target URL %q, got %q", cfg.Input, targets[0].URL)
+	}
+	if targets[0].Prefetched {
+		t.Fatalf("http targets should not be marked as prefetched")
+	}
+}
+
+func TestResolveTargetsFile(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "script.js")
+	if err := os.WriteFile(file, []byte("console.log('test');"), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	cfg := config.Config{Input: file}
+	targets, err := ResolveTargets(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target, got %d", len(targets))
+	}
+	wantPrefix := "file://"
+	if !strings.HasPrefix(targets[0].URL, wantPrefix) {
+		t.Fatalf("expected file target to have %q prefix, got %q", wantPrefix, targets[0].URL)
+	}
+}
+
+func TestResolveTargetsGlob(t *testing.T) {
+	dir := t.TempDir()
+	files := []string{"a.js", "b.js", "ignore.txt"}
+	for _, name := range files {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte("console.log('test');"), 0o644); err != nil {
+			t.Fatalf("write temp file: %v", err)
+		}
+	}
+
+	pattern := filepath.Join(dir, "*.js")
+	cfg := config.Config{Input: pattern}
+	targets, err := ResolveTargets(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("expected 2 targets, got %d", len(targets))
+	}
+}
+
+func TestResolveTargetsBurp(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "burp.xml")
+
+	body := base64.StdEncoding.EncodeToString([]byte("console.log('test');"))
+	data := `<items><item><url>https://example.com/app.js</url><response>` + body + `</response></item></items>`
+	if err := os.WriteFile(file, []byte(data), 0o644); err != nil {
+		t.Fatalf("write burp file: %v", err)
+	}
+
+	cfg := config.Config{Input: file, Burp: true}
+	targets, err := ResolveTargets(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target, got %d", len(targets))
+	}
+	if !targets[0].Prefetched {
+		t.Fatalf("burp targets should be prefetched")
+	}
+	if targets[0].Content == "" {
+		t.Fatalf("expected prefetched content to be populated")
+	}
+}
+
+func TestResolveFilePath(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "folder with space", "script.js")
+	if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	contents := "console.log('test');"
+	if err := os.WriteFile(file, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	abs, err := filepath.Abs(file)
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+
+	url := "file://" + filepath.ToSlash(abs)
+	if runtime.GOOS == "windows" {
+		url = "file:///" + filepath.ToSlash(abs)
+	}
+
+	data, err := ResolveFilePath(url)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if data != contents {
+		t.Fatalf("expected file contents %q, got %q", contents, data)
+	}
+}

--- a/internal/network/url_test.go
+++ b/internal/network/url_test.go
@@ -1,0 +1,69 @@
+package network
+
+import "testing"
+
+func TestCheckURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		base    string
+		wantURL string
+		wantOK  bool
+	}{
+		{
+			name:    "absolute url",
+			raw:     "https://cdn.example.com/app.js",
+			base:    "https://example.com/index.html",
+			wantURL: "https://cdn.example.com/app.js",
+			wantOK:  true,
+		},
+		{
+			name:    "protocol relative",
+			raw:     "//cdn.example.com/app.js",
+			base:    "https://example.com/index.html",
+			wantURL: "https://cdn.example.com/app.js",
+			wantOK:  true,
+		},
+		{
+			name:    "relative path",
+			raw:     "scripts/app.js",
+			base:    "https://example.com/app/page.html",
+			wantURL: "https://example.com/app/scripts/app.js",
+			wantOK:  true,
+		},
+		{
+			name:   "ignore node_modules",
+			raw:    "/node_modules/jquery.js",
+			base:   "https://example.com/app/page.html",
+			wantOK: false,
+		},
+		{
+			name:   "require js extension",
+			raw:    "/styles/app.css",
+			base:   "https://example.com/app/page.html",
+			wantOK: false,
+		},
+		{
+			name:    "relative with query",
+			raw:     "scripts/app.js?v=1",
+			base:    "https://example.com/app/page.html",
+			wantURL: "https://example.com/app/scripts/app.js?v=1",
+			wantOK:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := CheckURL(tt.raw, tt.base)
+			if ok != tt.wantOK {
+				t.Fatalf("expected ok=%v, got %v", tt.wantOK, ok)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if got != tt.wantURL {
+				t.Fatalf("expected url %q, got %q", tt.wantURL, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add unit coverage for parser endpoint extraction and highlighting behaviour
- cover URL resolution logic to ensure only valid script endpoints are accepted
- exercise input target resolution for http, file, glob, burp, and file:// paths

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e22d237bf48329ba2f70263b137dd7