### PR TITLE
Use zlib reader for deflate responses

### DIFF
--- a/internal/network/request.go
+++ b/internal/network/request.go
@@ -1,8 +1,8 @@
 package network
 
 import (
-	"compress/flate"
 	"compress/gzip"
+	"compress/zlib"
 	"io"
 	"net/http"
 
@@ -56,8 +56,11 @@ func decodeBody(resp *http.Response) (io.ReadCloser, error) {
 		}
 		return gz, nil
 	case "deflate":
-		fl := flate.NewReader(resp.Body)
-		return fl, nil
+		zr, err := zlib.NewReader(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		return zr, nil
 	default:
 		return resp.Body, nil
 	}

--- a/internal/network/request_test.go
+++ b/internal/network/request_test.go
@@ -1,0 +1,43 @@
+package network
+
+import (
+	"bytes"
+	"compress/zlib"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/example/GoLinkfinderEVO/internal/config"
+)
+
+func TestFetchDeflate(t *testing.T) {
+	const payload = "compressed content"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var buf bytes.Buffer
+		zw := zlib.NewWriter(&buf)
+		if _, err := zw.Write([]byte(payload)); err != nil {
+			t.Fatalf("failed to write deflate payload: %v", err)
+		}
+		if err := zw.Close(); err != nil {
+			t.Fatalf("failed to close deflate writer: %v", err)
+		}
+
+		w.Header().Set("Content-Encoding", "deflate")
+		if _, err := w.Write(buf.Bytes()); err != nil {
+			t.Fatalf("failed to write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	cfg := config.Config{Timeout: time.Second}
+	content, err := Fetch(server.URL, cfg)
+	if err != nil {
+		t.Fatalf("Fetch returned error: %v", err)
+	}
+
+	if content != payload {
+		t.Fatalf("unexpected content: got %q want %q", content, payload)
+	}
+}


### PR DESCRIPTION
## Summary
- switch deflate response handling to use compress/zlib for proper decoding
- add regression test to ensure Fetch correctly reads deflate-compressed responses

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e22dc5119c8329be09a7661726ed77