### PR TITLE
Allow configurable script extensions and add tests

### DIFF
--- a/internal/network/url.go
+++ b/internal/network/url.go
@@ -4,6 +4,8 @@ import (
 	"net/url"
 	"path"
 	"strings"
+
+	"github.com/example/GoLinkfinderEVO/internal/parser"
 )
 
 // CheckURL validates a JS endpoint and resolves it to an absolute URL based on the provided base.
@@ -19,7 +21,7 @@ func CheckURL(raw, base string) (string, bool) {
 	}
 
 	lowerTrimmed := strings.ToLower(trimmed)
-	if !strings.HasSuffix(lowerTrimmed, ".js") {
+	if !parser.ScriptExtensionRegex().MatchString(lowerTrimmed) {
 		return "", false
 	}
 

--- a/internal/network/url_test.go
+++ b/internal/network/url_test.go
@@ -1,0 +1,72 @@
+package network
+
+import (
+	"testing"
+
+	"github.com/example/GoLinkfinderEVO/internal/parser"
+)
+
+func TestCheckURLScriptExtensions(t *testing.T) {
+	defaultExts := []string{".js", ".mjs", ".jsx", ".ts", ".tsx"}
+	parser.SetScriptExtensions(defaultExts)
+	t.Cleanup(func() {
+		parser.SetScriptExtensions(defaultExts)
+	})
+
+	base := "https://example.com/index.html"
+
+	tests := []struct {
+		name string
+		raw  string
+		ok   bool
+		want string
+	}{
+		{
+			name: "JavaScript",
+			raw:  "app.js",
+			ok:   true,
+			want: "https://example.com/app.js",
+		},
+		{
+			name: "ECMAScript module",
+			raw:  "https://cdn.example.com/app.mjs",
+			ok:   true,
+			want: "https://cdn.example.com/app.mjs",
+		},
+		{
+			name: "JSX with query and fragment",
+			raw:  "/assets/app.jsx?v=1#section",
+			ok:   true,
+			want: "https://example.com/assets/app.jsx?v=1#section",
+		},
+		{
+			name: "TypeScript",
+			raw:  "//static.example.com/app.ts",
+			ok:   true,
+			want: "https://static.example.com/app.ts",
+		},
+		{
+			name: "TSX uppercase",
+			raw:  "SCRIPTS/MAIN.TSX",
+			ok:   true,
+			want: "https://example.com/SCRIPTS/MAIN.TSX",
+		},
+		{
+			name: "Non script extension",
+			raw:  "styles.css",
+			ok:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := CheckURL(tt.raw, base)
+			if ok != tt.ok {
+				t.Fatalf("expected ok=%v, got %v (result %q)", tt.ok, ok, got)
+			}
+			if ok && got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- update URL validation to rely on a configurable script-extension regex shared with the parser
- expose parser helpers to manage script extensions and add coverage for multiple extensions

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e22dcbd774832999be4de7a128f431