### PR TITLE
Handle directory inputs when resolving file targets

### DIFF
--- a/internal/input/input.go
+++ b/internal/input/input.go
@@ -39,7 +39,10 @@ func ResolveTargets(cfg config.Config) ([]model.Target, error) {
 		return resolveGlob(input)
 	}
 
-	if _, err := os.Stat(input); err == nil {
+	if info, err := os.Stat(input); err == nil {
+		if info.IsDir() {
+			return nil, errors.New("directories require a wildcard (e.g. dir/*.js)")
+		}
 		abs, err := filepath.Abs(input)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary
- store the result of os.Stat when resolving file inputs
- return an explicit error when the provided path is a directory
- only construct file:// targets for non-directory inputs

## Testing
- go test ./... (hangs in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e22dfe96cc8329a23134815b1882af