### PR TITLE
Improve CLI flag descriptions and aliases

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,9 @@ package config
 import (
 	"errors"
 	"flag"
+	"fmt"
+	"os"
+	"strconv"
 	"time"
 )
 
@@ -19,29 +22,127 @@ type Config struct {
 
 // ParseFlags parses CLI flags into a Config value.
 func ParseFlags() (Config, error) {
-	cfg := Config{}
+	cfg := Config{Timeout: 10 * time.Second}
 
-	flag.BoolVar(&cfg.Domain, "domain", false, "Input a domain to recursively parse all javascript located in a page")
-	flag.BoolVar(&cfg.Domain, "d", false, "Input a domain to recursively parse all javascript located in a page")
-	flag.StringVar(&cfg.Input, "input", "", "Input a: URL, file or folder. For folders a wildcard can be used (e.g. '/*.js').")
-	flag.StringVar(&cfg.Input, "i", "", "Input a: URL, file or folder. For folders a wildcard can be used (e.g. '/*.js').")
-	flag.StringVar(&cfg.Output, "output", "", "Where to save the HTML report, including file name. Leave empty for CLI output.")
-	flag.StringVar(&cfg.Output, "o", "", "Where to save the HTML report, including file name. Leave empty for CLI output.")
-	flag.StringVar(&cfg.Regex, "regex", "", "RegEx for filtering purposes against found endpoint (e.g. ^/api/)")
-	flag.StringVar(&cfg.Regex, "r", "", "RegEx for filtering purposes against found endpoint (e.g. ^/api/)")
-	flag.BoolVar(&cfg.Burp, "burp", false, "")
-	flag.BoolVar(&cfg.Burp, "b", false, "")
-	flag.StringVar(&cfg.Cookies, "cookies", "", "Add cookies for authenticated JS files")
-	flag.StringVar(&cfg.Cookies, "c", "", "Add cookies for authenticated JS files")
-	timeout := flag.Int("timeout", 10, "How many seconds to wait for the server to send data before giving up")
-	flag.IntVar(timeout, "t", 10, "How many seconds to wait for the server to send data before giving up")
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [OPTIONS]\n\n", os.Args[0])
+		fmt.Fprintln(flag.CommandLine.Output(), "Options:")
+		flag.PrintDefaults()
+	}
+
+	flag.BoolVar(&cfg.Domain, "domain", false, "Recursively parse JavaScript resources discovered on the provided domain.")
+	registerBoolAlias("d", "domain", &cfg.Domain)
+
+	flag.StringVar(&cfg.Input, "input", "", "URL, file or folder to analyse. For folders you can use wildcards (e.g. '/*.js').")
+	registerStringAlias("i", "input", &cfg.Input)
+
+	flag.StringVar(&cfg.Output, "output", "", "Save the HTML report to this path. Leave empty for CLI output.")
+	registerStringAlias("o", "output", &cfg.Output)
+
+	flag.StringVar(&cfg.Regex, "regex", "", "Only report endpoints matching the provided regular expression (e.g. '^/api/').")
+	registerStringAlias("r", "regex", &cfg.Regex)
+
+	flag.BoolVar(&cfg.Burp, "burp", false, "Treat the input as a Burp Suite XML export.")
+	registerBoolAlias("b", "burp", &cfg.Burp)
+
+	flag.StringVar(&cfg.Cookies, "cookies", "", "Include cookies when fetching authenticated JavaScript files.")
+	registerStringAlias("c", "cookies", &cfg.Cookies)
+
+	flag.DurationVar(&cfg.Timeout, "timeout", cfg.Timeout, "Maximum time to wait for server responses (e.g. 10s, 1m).")
+	registerDurationAlias("t", "timeout", &cfg.Timeout)
 
 	flag.Parse()
-	cfg.Timeout = time.Duration(*timeout) * time.Second
 
 	if cfg.Input == "" {
 		return cfg, errors.New("-i/--input is required")
 	}
 
 	return cfg, nil
+}
+
+func registerStringAlias(name, canonical string, target *string) {
+	flag.CommandLine.Var(&stringAlias{target: target}, name, fmt.Sprintf("Alias for --%s", canonical))
+}
+
+func registerBoolAlias(name, canonical string, target *bool) {
+	flag.CommandLine.Var(&boolAlias{target: target}, name, fmt.Sprintf("Alias for --%s", canonical))
+}
+
+func registerDurationAlias(name, canonical string, target *time.Duration) {
+	flag.CommandLine.Var(&durationAlias{target: target}, name, fmt.Sprintf("Alias for --%s", canonical))
+}
+
+type stringAlias struct {
+	target *string
+}
+
+func (s *stringAlias) Set(value string) error {
+	*s.target = value
+	return nil
+}
+
+func (s *stringAlias) String() string {
+	if s.target == nil {
+		return ""
+	}
+	return *s.target
+}
+
+type boolAlias struct {
+	target *bool
+}
+
+func (b *boolAlias) Set(value string) error {
+	if value == "" {
+		*b.target = true
+		return nil
+	}
+
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return err
+	}
+	*b.target = parsed
+	return nil
+}
+
+func (b *boolAlias) String() string {
+	if b.target == nil {
+		return "false"
+	}
+	return strconv.FormatBool(*b.target)
+}
+
+func (b *boolAlias) IsBoolFlag() bool {
+	return true
+}
+
+type durationAlias struct {
+	target *time.Duration
+}
+
+func (d *durationAlias) Set(value string) error {
+	if value == "" {
+		return errors.New("duration flag requires a value")
+	}
+
+	parsed, err := time.ParseDuration(value)
+	if err != nil {
+		seconds, convErr := strconv.Atoi(value)
+		if convErr != nil {
+			return err
+		}
+		*d.target = time.Duration(seconds) * time.Second
+		return nil
+	}
+
+	*d.target = parsed
+	return nil
+}
+
+func (d *durationAlias) String() string {
+	if d.target == nil {
+		return ""
+	}
+	return d.target.String()
 }


### PR DESCRIPTION
## Summary
- clarify flag help text and usage output to make options easier to understand
- add reusable helpers for short flag aliases and support duration-based timeout values

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e22fd896bc8329828d89dcd7eafde4