### PR TITLE
Add scope flag to limit recursive JavaScript fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Implementation of the original LinkFinder utility in Go.
 ## Usage
 
 ```bash
-go run . -i <target> [-o output.html] [--regex <filter>] [--domain] [--cookies <cookie-string>] [--timeout <seconds>]
+go run . -i <target> [-o output.html] [--regex <filter>] [--domain] [--scope <domain>] [--cookies <cookie-string>] [--timeout <seconds>]
 ```
 
 The tool now prints matches to stdout in raw format by default. Provide `-o <file.html>` if you want to save the HTML report instead. The program accepts the same kinds of inputs as the Python version, including URLs, local files, wildcards and Burp XML exports (`-b`).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 // Config contains runtime configuration provided via flags.
 type Config struct {
 	Domain  bool
+	Scope   string
 	Input   string
 	Output  string
 	Regex   string
@@ -31,6 +32,7 @@ func ParseFlags() (Config, error) {
 		fmt.Fprintln(out, "Options:")
 
 		printOption(out, "domain", "d", "", "Recursively parse JavaScript resources discovered on the provided domain.", "")
+		printOption(out, "scope", "s", "string", "Restrict recursive JavaScript fetching to the specified domain (e.g. example.com).", "")
 		printOption(out, "input", "i", "string", "URL, file or folder to analyse. For folders you can use wildcards (e.g. '/*.js').", "")
 		printOption(out, "output", "o", "string", "Save the HTML report to this path. Leave empty for CLI output.", "")
 		printOption(out, "regex", "r", "string", "Only report endpoints matching the provided regular expression (e.g. '^/api/').", "")
@@ -41,6 +43,9 @@ func ParseFlags() (Config, error) {
 
 	flag.BoolVar(&cfg.Domain, "domain", false, "Recursively parse JavaScript resources discovered on the provided domain.")
 	registerBoolAlias("d", "domain", &cfg.Domain)
+
+	flag.StringVar(&cfg.Scope, "scope", "", "Restrict recursive JavaScript fetching to the specified domain (e.g. example.com).")
+	registerStringAlias("s", "scope", &cfg.Scope)
 
 	flag.StringVar(&cfg.Input, "input", "", "URL, file or folder to analyse. For folders you can use wildcards (e.g. '/*.js').")
 	registerStringAlias("i", "input", &cfg.Input)

--- a/internal/network/url.go
+++ b/internal/network/url.go
@@ -74,3 +74,36 @@ func CheckURL(raw, base string) (string, bool) {
 
 	return resolved.String(), true
 }
+
+// WithinScope reports whether the provided resource URL belongs to the supplied scope domain.
+// The scope can be provided with or without a scheme (e.g. "https://example.com" or "example.com").
+func WithinScope(resource, scope string) bool {
+	if scope == "" {
+		return true
+	}
+
+	parsedResource, err := url.Parse(resource)
+	if err != nil {
+		return false
+	}
+
+	resourceHost := parsedResource.Hostname()
+	if resourceHost == "" {
+		return false
+	}
+
+	parsedScope, err := url.Parse(scope)
+	if err != nil || parsedScope.Hostname() == "" {
+		parsedScope, err = url.Parse("https://" + scope)
+		if err != nil {
+			return false
+		}
+	}
+
+	scopeHost := parsedScope.Hostname()
+	if scopeHost == "" {
+		return false
+	}
+
+	return strings.EqualFold(resourceHost, scopeHost)
+}

--- a/internal/network/url_test.go
+++ b/internal/network/url_test.go
@@ -67,3 +67,52 @@ func TestCheckURL(t *testing.T) {
 		})
 	}
 }
+
+func TestWithinScope(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource string
+		scope    string
+		want     bool
+	}{
+		{
+			name:     "matching host with scheme",
+			resource: "https://static.example.com/app.js",
+			scope:    "https://static.example.com",
+			want:     true,
+		},
+		{
+			name:     "matching host without scope scheme",
+			resource: "https://example.com/app.js",
+			scope:    "example.com",
+			want:     true,
+		},
+		{
+			name:     "different host",
+			resource: "https://cdn.example.com/app.js",
+			scope:    "example.com",
+			want:     false,
+		},
+		{
+			name:     "ignore port in resource",
+			resource: "https://example.com:8443/app.js",
+			scope:    "https://example.com",
+			want:     true,
+		},
+		{
+			name:     "invalid scope",
+			resource: "https://example.com/app.js",
+			scope:    "://",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := WithinScope(tt.resource, tt.scope)
+			if got != tt.want {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -90,6 +90,10 @@ func processDomain(cfg config.Config, baseResource string, endpoints []model.End
 			continue
 		}
 
+		if cfg.Scope != "" && !network.WithinScope(resolved, cfg.Scope) {
+			continue
+		}
+
 		if visited != nil {
 			if _, seen := visited[resolved]; seen {
 				continue


### PR DESCRIPTION
## Summary
- add a --scope flag to limit recursive JavaScript fetching to a single domain
- skip recursion for endpoints outside the configured scope and document the new option
- cover the scope matching helper with dedicated tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e23335f120832993acf662c73435c4