### PR TITLE
Add raw export option and refresh HTML report

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Implementation of the original LinkFinder utility in Go.
 ## Usage
 
 ```bash
-go run . -i <target> [-o output.html] [--regex <filter>] [--domain] [--cookies <cookie-string>] [--timeout <seconds>]
+go run . -i <target> [-o output.html] [--raw results.txt] [--regex <filter>] [--domain] [--cookies <cookie-string>] [--timeout <seconds>]
 ```
 
-The tool now prints matches to stdout in raw format by default. Provide `-o <file.html>` if you want to save the HTML report instead. The program accepts the same kinds of inputs as the Python version, including URLs, local files, wildcards and Burp XML exports (`-b`).
+The tool now prints matches to stdout in raw format by default. Provide `-o <file.html>` if you want to save the HTML report instead, or `--raw <file>` to export a machine-friendly plaintext list. The program accepts the same kinds of inputs as the Python version, including URLs, local files, wildcards and Burp XML exports (`-b`).
 
 The HTML report template is now embedded within the binary, so you no longer need to keep `template.html` alongside the executable when running the tool.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	Domain  bool
 	Input   string
 	Output  string
+	Raw     string
 	Regex   string
 	Burp    bool
 	Cookies string
@@ -33,6 +34,7 @@ func ParseFlags() (Config, error) {
 		printOption(out, "domain", "d", "", "Recursively parse JavaScript resources discovered on the provided domain.", "")
 		printOption(out, "input", "i", "string", "URL, file or folder to analyse. For folders you can use wildcards (e.g. '/*.js').", "")
 		printOption(out, "output", "o", "string", "Save the HTML report to this path. Leave empty for CLI output.", "")
+		printOption(out, "raw", "", "string", "Write the extracted endpoints to a plaintext file.", "")
 		printOption(out, "regex", "r", "string", "Only report endpoints matching the provided regular expression (e.g. '^/api/').", "")
 		printOption(out, "burp", "b", "", "Treat the input as a Burp Suite XML export.", "")
 		printOption(out, "cookies", "c", "string", "Include cookies when fetching authenticated JavaScript files.", "")
@@ -47,6 +49,9 @@ func ParseFlags() (Config, error) {
 
 	flag.StringVar(&cfg.Output, "output", "", "Save the HTML report to this path. Leave empty for CLI output.")
 	registerStringAlias("o", "output", &cfg.Output)
+
+	flag.StringVar(&cfg.Raw, "raw", "", "Write the extracted endpoints to a plaintext file.")
+	registerStringAlias("raw-output", "raw", &cfg.Raw)
 
 	flag.StringVar(&cfg.Regex, "regex", "", "Only report endpoints matching the provided regular expression (e.g. '^/api/').")
 	registerStringAlias("r", "regex", &cfg.Regex)

--- a/internal/output/cli.go
+++ b/internal/output/cli.go
@@ -1,24 +1,29 @@
 package output
 
-import (
-	"fmt"
-
-	"github.com/example/GoLinkfinderEVO/internal/model"
-)
+import "fmt"
 
 // PrintCLI prints endpoints to stdout in CLI mode.
-func PrintCLI(resource string, endpoints []model.Endpoint) {
-	fmt.Printf("File: %s\n", resource)
+func PrintCLI(report ResourceReport) {
+	fmt.Printf("Resource: %s\n", report.Resource)
+	fmt.Printf("  Endpoints discovered: %d\n", len(report.Endpoints))
 
-	if len(endpoints) == 0 {
+	if len(report.Endpoints) == 0 {
 		fmt.Println("  No endpoints were found.")
 		fmt.Println()
 		return
 	}
 
-	for _, ep := range endpoints {
-		fmt.Printf("  %s\n", ep.Link)
+	for _, ep := range report.Endpoints {
+		fmt.Printf("    - %s\n", ep.Link)
 	}
 
 	fmt.Println()
+}
+
+// PrintSummary prints an aggregated summary once all resources have been processed.
+func PrintSummary(meta Metadata) {
+	fmt.Println("Summary")
+	fmt.Println("=======")
+	fmt.Printf("Resources scanned : %d\n", meta.TotalResources)
+	fmt.Printf("Endpoints discovered: %d\n", meta.TotalEndpoints)
 }

--- a/internal/output/html.go
+++ b/internal/output/html.go
@@ -3,49 +3,106 @@ package output
 import (
 	"bytes"
 	"fmt"
-	"html"
+	htmlstd "html"
+	"html/template"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
-	"text/template"
+	"time"
 
-	"github.com/example/GoLinkfinderEVO/internal/model"
 	"github.com/example/GoLinkfinderEVO/internal/parser"
 )
 
 // AppendHTML appends the HTML representation of the endpoints for a resource.
-func AppendHTML(builder *strings.Builder, resource string, endpoints []model.Endpoint) {
-	escapedURL := html.EscapeString(resource)
-	builder.WriteString("\n                <h1>File: <a href=\"")
+func AppendHTML(builder *strings.Builder, report ResourceReport) {
+	if builder == nil {
+		return
+	}
+
+	escapedURL := htmlstd.EscapeString(report.Resource)
+
+	builder.WriteString("\n        <section class=\"resource\">")
+	builder.WriteString("\n            <header class=\"resource-header\">")
+	builder.WriteString("\n                <h2 class=\"resource-title\"><a href=\"")
 	builder.WriteString(escapedURL)
 	builder.WriteString("\" target=\"_blank\" rel=\"nofollow noopener noreferrer\">")
 	builder.WriteString(escapedURL)
-	builder.WriteString("</a></h1>\n")
-
-	for _, ep := range endpoints {
-		safeLink := html.EscapeString(ep.Link)
-		builder.WriteString("                <div><a href=\"")
-		builder.WriteString(safeLink)
-		builder.WriteString("\" class='text'>")
-		builder.WriteString(safeLink)
-		builder.WriteString("</a><div class='container'>")
-		builder.WriteString(parser.HighlightContext(ep.Context, ep.Link))
-		builder.WriteString("</div></div>\n")
+	builder.WriteString("</a></h2>")
+	builder.WriteString("\n                <span class=\"badge\">")
+	count := report.EndpointCount()
+	builder.WriteString(fmt.Sprintf("%d endpoint", count))
+	if count != 1 {
+		builder.WriteString("s")
 	}
+	builder.WriteString("</span>")
+	builder.WriteString("\n            </header>")
+
+	if len(report.Endpoints) == 0 {
+		builder.WriteString("\n            <p class=\"resource-empty\">No endpoints were found for this resource.</p>")
+		builder.WriteString("\n        </section>")
+		return
+	}
+
+	builder.WriteString("\n            <ul class=\"endpoint-list\">")
+	for idx, ep := range report.Endpoints {
+		safeLink := htmlstd.EscapeString(ep.Link)
+		builder.WriteString("\n                <li class=\"endpoint-item\">")
+		builder.WriteString("\n                    <div class=\"endpoint-header\">")
+		builder.WriteString(fmt.Sprintf("\n                        <span class=\"endpoint-index\">#%d</span>", idx+1))
+		builder.WriteString("\n                        <a href=\"")
+		builder.WriteString(safeLink)
+		builder.WriteString("\" class=\"endpoint-link\" target=\"_blank\" rel=\"nofollow noopener noreferrer\">")
+		builder.WriteString(safeLink)
+		builder.WriteString("</a>")
+		builder.WriteString("\n                        <button type=\"button\" class=\"copy-button\" data-copy=\"")
+		builder.WriteString(safeLink)
+		builder.WriteString("\">Copy</button>")
+		builder.WriteString("\n                    </div>")
+
+		if ep.Context != "" {
+			builder.WriteString("\n                    <pre class=\"endpoint-context\"><code>")
+			builder.WriteString(parser.HighlightContext(ep.Context, ep.Link))
+			builder.WriteString("</code></pre>")
+		}
+
+		builder.WriteString("\n                </li>")
+	}
+	builder.WriteString("\n            </ul>")
+	builder.WriteString("\n        </section>")
 }
 
 // SaveHTML renders the final HTML report to the provided output path.
-func SaveHTML(content, outputPath string) error {
+func SaveHTML(content, outputPath string, meta Metadata) error {
 	tpl, err := template.New("output").Parse(templateHTML)
 	if err != nil {
 		return err
 	}
 
 	var buf bytes.Buffer
-	if err := tpl.Execute(&buf, map[string]any{"Content": content}); err != nil {
+	data := struct {
+		Content        template.HTML
+		GeneratedAt    string
+		TotalResources int
+		TotalEndpoints int
+		HasResults     bool
+	}{
+		Content:        template.HTML(content),
+		GeneratedAt:    meta.GeneratedAt.Format(time.RFC1123),
+		TotalResources: meta.TotalResources,
+		TotalEndpoints: meta.TotalEndpoints,
+		HasResults:     meta.TotalResources > 0,
+	}
+
+	if err := tpl.Execute(&buf, data); err != nil {
 		return err
+	}
+
+	if dir := filepath.Dir(outputPath); dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil && !os.IsExist(err) {
+			return err
+		}
 	}
 
 	if err := os.WriteFile(outputPath, buf.Bytes(), 0o644); err != nil {

--- a/internal/output/report.go
+++ b/internal/output/report.go
@@ -1,0 +1,93 @@
+package output
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/example/GoLinkfinderEVO/internal/model"
+)
+
+// ResourceReport describes the endpoints discovered for a single resource.
+type ResourceReport struct {
+	Resource  string
+	Endpoints []model.Endpoint
+}
+
+// EndpointCount returns the number of endpoints discovered for the resource.
+func (r ResourceReport) EndpointCount() int {
+	return len(r.Endpoints)
+}
+
+// Metadata captures aggregated information about a run.
+type Metadata struct {
+	GeneratedAt    time.Time
+	TotalResources int
+	TotalEndpoints int
+}
+
+// BuildMetadata creates a Metadata value from the provided reports.
+func BuildMetadata(reports []ResourceReport, generatedAt time.Time) Metadata {
+	return Metadata{
+		GeneratedAt:    generatedAt,
+		TotalResources: len(reports),
+		TotalEndpoints: TotalEndpoints(reports),
+	}
+}
+
+// TotalEndpoints counts the endpoints across all reports.
+func TotalEndpoints(reports []ResourceReport) int {
+	total := 0
+	for _, report := range reports {
+		total += len(report.Endpoints)
+	}
+	return total
+}
+
+// WriteRaw writes the discovered endpoints to a plaintext file.
+func WriteRaw(path string, reports []ResourceReport, meta Metadata) error {
+	var buf bytes.Buffer
+
+	buf.WriteString("# GoLinkfinderEVO raw results\n")
+	buf.WriteString(fmt.Sprintf("# Generated at: %s\n", meta.GeneratedAt.Format(time.RFC3339)))
+	buf.WriteString(fmt.Sprintf("# Resources scanned: %d\n", meta.TotalResources))
+	buf.WriteString(fmt.Sprintf("# Total endpoints: %d\n\n", meta.TotalEndpoints))
+
+	for _, report := range reports {
+		buf.WriteString("[Resource] ")
+		buf.WriteString(report.Resource)
+		buf.WriteByte('\n')
+
+		if len(report.Endpoints) == 0 {
+			buf.WriteString("#   No endpoints were found.\n\n")
+			continue
+		}
+
+		for _, ep := range report.Endpoints {
+			buf.WriteString(ep.Link)
+			buf.WriteByte('\n')
+
+			trimmed := strings.TrimSpace(ep.Context)
+			if trimmed != "" {
+				for _, line := range strings.Split(trimmed, "\n") {
+					buf.WriteString("#   ")
+					buf.WriteString(line)
+					buf.WriteByte('\n')
+				}
+			}
+
+			buf.WriteByte('\n')
+		}
+	}
+
+	if dir := filepath.Dir(path); dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil && !os.IsExist(err) {
+			return err
+		}
+	}
+
+	return os.WriteFile(path, buf.Bytes(), 0o644)
+}

--- a/internal/output/template.html
+++ b/internal/output/template.html
@@ -3,43 +3,306 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>GoLinkfinderEVO Output</title>
+    <title>GoLinkfinderEVO Results</title>
     <style>
-        body {
-            font-family: Arial, sans-serif;
-            background-color: #1e1e1e;
-            color: #f0f0f0;
-            margin: 0;
-            padding: 2rem;
+        :root {
+            color-scheme: dark;
+            font-family: 'Segoe UI', Roboto, sans-serif;
+            background-color: #0f172a;
+            color: #e2e8f0;
         }
-        h1 {
-            color: #61dafb;
-            font-size: 1.5rem;
+
+        body {
+            margin: 0;
+            padding: 0 1.5rem 3rem;
+        }
+
+        main {
+            max-width: 1100px;
+            margin: 0 auto;
+        }
+
+        .page-header {
+            padding: 2.5rem 0 1.5rem;
+        }
+
+        .page-header h1 {
+            margin: 0;
+            font-size: 2.25rem;
+            color: #38bdf8;
+        }
+
+        .page-header p {
+            margin: 0.75rem 0 0;
+            color: #94a3b8;
+        }
+
+        .summary-grid {
+            margin-top: 1.5rem;
+            display: grid;
+            gap: 1rem;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        }
+
+        .summary-card {
+            background: rgba(148, 163, 184, 0.12);
+            border: 1px solid rgba(148, 163, 184, 0.2);
+            border-radius: 12px;
+            padding: 1rem 1.25rem;
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .summary-label {
+            font-size: 0.9rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: #cbd5f5;
+        }
+
+        .summary-value {
+            font-size: 1.75rem;
+            font-weight: 600;
+        }
+
+        .results {
             margin-top: 2rem;
         }
-        a.text {
-            color: #ffd700;
+
+        .resource {
+            background: rgba(15, 23, 42, 0.6);
+            border: 1px solid rgba(148, 163, 184, 0.2);
+            border-radius: 14px;
+            margin-bottom: 1.5rem;
+            overflow: hidden;
+            box-shadow: 0 18px 35px rgba(15, 23, 42, 0.45);
+        }
+
+        .resource-header {
+            padding: 1.25rem 1.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+            align-items: center;
+            justify-content: space-between;
+            background: linear-gradient(135deg, rgba(14, 165, 233, 0.16), rgba(59, 130, 246, 0.08));
+        }
+
+        .resource-title {
+            margin: 0;
+            font-size: 1.25rem;
+        }
+
+        .resource-title a {
+            color: #f8fafc;
             text-decoration: none;
             word-break: break-all;
         }
-        a.text:hover {
+
+        .resource-title a:hover {
             text-decoration: underline;
         }
-        .container {
-            background-color: #2b2b2b;
-            border-radius: 8px;
-            margin: 0.5rem 0 1.5rem;
-            padding: 1rem;
-            white-space: pre-wrap;
-            word-break: break-word;
+
+        .badge {
+            background: rgba(14, 165, 233, 0.2);
+            color: #bae6fd;
+            border-radius: 999px;
+            padding: 0.3rem 0.9rem;
+            font-size: 0.85rem;
+            font-weight: 600;
         }
-        span {
-            font-weight: bold;
+
+        .resource-empty {
+            margin: 0;
+            padding: 1.5rem;
+            color: #94a3b8;
+            font-style: italic;
+        }
+
+        .endpoint-list {
+            list-style: none;
+            padding: 0 1.5rem 1.5rem;
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+
+        .endpoint-item {
+            background: rgba(30, 41, 59, 0.6);
+            border: 1px solid rgba(148, 163, 184, 0.18);
+            border-radius: 12px;
+            padding: 1rem 1.25rem;
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+        }
+
+        .endpoint-header {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+            align-items: center;
+            justify-content: space-between;
+        }
+
+        .endpoint-index {
+            background: rgba(168, 85, 247, 0.2);
+            color: #e9d5ff;
+            border-radius: 999px;
+            padding: 0.2rem 0.7rem;
+            font-size: 0.85rem;
+            font-weight: 600;
+        }
+
+        .endpoint-link {
+            color: #fbbf24;
+            text-decoration: none;
+            word-break: break-all;
+            flex: 1 1 auto;
+        }
+
+        .endpoint-link:hover {
+            text-decoration: underline;
+        }
+
+        .copy-button {
+            background: rgba(59, 130, 246, 0.25);
+            color: #e2e8f0;
+            border: 1px solid rgba(59, 130, 246, 0.35);
+            border-radius: 8px;
+            padding: 0.45rem 0.9rem;
+            cursor: pointer;
+            font-size: 0.85rem;
+            transition: background 0.2s ease, transform 0.2s ease;
+        }
+
+        .copy-button:hover {
+            background: rgba(59, 130, 246, 0.45);
+            transform: translateY(-1px);
+        }
+
+        .copy-button.copied {
+            background: rgba(34, 197, 94, 0.45);
+            border-color: rgba(34, 197, 94, 0.6);
+        }
+
+        .endpoint-context {
+            margin: 0;
+            padding: 1rem;
+            background: rgba(15, 23, 42, 0.75);
+            border-radius: 10px;
+            overflow-x: auto;
+            font-size: 0.85rem;
+            line-height: 1.5;
+            color: #cbd5f5;
+        }
+
+        .endpoint-context code {
+            font-family: 'Fira Code', 'Source Code Pro', monospace;
+            white-space: pre-wrap;
+        }
+
+        mark.highlight {
+            background: rgba(250, 204, 21, 0.45);
+            border-radius: 4px;
+            padding: 0 0.1rem;
+        }
+
+        .empty-state {
+            color: #94a3b8;
+            font-style: italic;
+        }
+
+        footer {
+            margin-top: 3rem;
+            padding-top: 1.5rem;
+            border-top: 1px solid rgba(148, 163, 184, 0.18);
+            color: #64748b;
+            font-size: 0.85rem;
+            text-align: center;
+        }
+
+        @media (max-width: 640px) {
+            .page-header {
+                padding-top: 2rem;
+            }
+
+            .resource-header {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+
+            .endpoint-header {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+
+            .copy-button {
+                align-self: flex-end;
+            }
         }
     </style>
 </head>
 <body>
-    <h1>GoLinkfinderEVO Results</h1>
-    {{.Content}}
+    <main>
+        <header class="page-header">
+            <h1>GoLinkfinderEVO Results</h1>
+            <p>Generated at {{.GeneratedAt}}</p>
+            <div class="summary-grid">
+                <div class="summary-card">
+                    <span class="summary-label">Resources scanned</span>
+                    <span class="summary-value">{{.TotalResources}}</span>
+                </div>
+                <div class="summary-card">
+                    <span class="summary-label">Endpoints discovered</span>
+                    <span class="summary-value">{{.TotalEndpoints}}</span>
+                </div>
+            </div>
+        </header>
+
+        <section class="results">
+            {{if .HasResults}}
+                {{.Content}}
+            {{else}}
+                <p class="empty-state">No resources were processed.</p>
+            {{end}}
+        </section>
+
+        <footer>
+            Report generated by GoLinkfinderEVO.
+        </footer>
+    </main>
+
+    <script>
+        document.addEventListener('click', function (event) {
+            const button = event.target.closest('[data-copy]');
+            if (!button) {
+                return;
+            }
+
+            const value = button.getAttribute('data-copy');
+            if (!value) {
+                return;
+            }
+
+            navigator.clipboard.writeText(value).then(() => {
+                const original = button.textContent;
+                button.textContent = 'Copied!';
+                button.classList.add('copied');
+                setTimeout(() => {
+                    button.textContent = original;
+                    button.classList.remove('copied');
+                }, 1600);
+            }).catch(() => {
+                const original = button.textContent;
+                button.textContent = 'Press Ctrl+C';
+                setTimeout(() => {
+                    button.textContent = original;
+                }, 1600);
+            });
+        });
+    </script>
 </body>
 </html>

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -190,8 +190,7 @@ func beautify(content string) string {
 func HighlightContext(context, link string) string {
 	escapedContext := html.EscapeString(context)
 	escapedLink := html.EscapeString(link)
-	highlight := strings.ReplaceAll(escapedContext, escapedLink, "<span style='background-color:yellow'>"+escapedLink+"</span>")
-	return highlight
+	return strings.ReplaceAll(escapedContext, escapedLink, "<mark class='highlight'>"+escapedLink+"</mark>")
 }
 
 func mustCompileScriptExtensions(exts []string) *regexp.Regexp {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -56,8 +56,8 @@ func TestHighlightContext(t *testing.T) {
 		t.Fatalf("expected context to be highlighted")
 	}
 
-	if !regexp.MustCompile(`<span style='background-color:yellow'>`).MatchString(highlighted) {
-		t.Fatalf("expected highlight span in context, got %q", highlighted)
+	if !regexp.MustCompile(`<mark class='highlight'>`).MatchString(highlighted) {
+		t.Fatalf("expected highlighted mark element in context, got %q", highlighted)
 	}
 
 	if !regexp.MustCompile(regexp.QuoteMeta(link)).MatchString(highlighted) {

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/example/GoLinkfinderEVO/internal/config"
 	"github.com/example/GoLinkfinderEVO/internal/input"
@@ -37,7 +38,15 @@ func main() {
 
 	endpointRegex := parser.EndpointRegex()
 
-	var outputBuilder strings.Builder
+	generatedAt := time.Now()
+
+	var htmlBuilder strings.Builder
+	var builder *strings.Builder
+	if mode == output.ModeHTML {
+		builder = &htmlBuilder
+	}
+
+	reports := make([]output.ResourceReport, 0, len(targets))
 
 	for _, t := range targets {
 		content, err := resolveContent(t, cfg)
@@ -47,20 +56,33 @@ func main() {
 
 		endpoints := parser.FindEndpoints(content, endpointRegex, mode == output.ModeHTML, filterRegex, true)
 
+		report := output.ResourceReport{Resource: t.URL, Endpoints: endpoints}
+		render(mode, report, builder)
+		reports = append(reports, report)
+
 		if cfg.Domain {
 			visited := map[string]struct{}{}
-			processDomain(cfg, t.URL, endpoints, endpointRegex, filterRegex, mode, &outputBuilder, visited)
+			processDomain(cfg, t.URL, endpoints, endpointRegex, filterRegex, mode, builder, &reports, visited)
 		}
+	}
 
-		render(mode, t.URL, endpoints, &outputBuilder)
+	meta := output.BuildMetadata(reports, generatedAt)
+
+	if cfg.Raw != "" {
+		if err := output.WriteRaw(cfg.Raw, reports, meta); err != nil {
+			exitWithError(fmt.Errorf("unable to write raw output: %w", err))
+		}
 	}
 
 	if mode == output.ModeHTML {
-		if err := output.SaveHTML(outputBuilder.String(), cfg.Output); err != nil {
+		if err := output.SaveHTML(htmlBuilder.String(), cfg.Output, meta); err != nil {
 			fmt.Fprintf(os.Stderr, "Output can't be saved in %s due to exception: %v\n", cfg.Output, err)
 			os.Exit(1)
 		}
+		return
 	}
+
+	output.PrintSummary(meta)
 }
 
 func determineMode(outputFlag string) output.Mode {
@@ -83,7 +105,7 @@ func resolveContent(t model.Target, cfg config.Config) (string, error) {
 }
 
 func processDomain(cfg config.Config, baseResource string, endpoints []model.Endpoint, regex *regexp.Regexp, filter *regexp.Regexp,
-	mode output.Mode, builder *strings.Builder, visited map[string]struct{}) {
+	mode output.Mode, builder *strings.Builder, reports *[]output.ResourceReport, visited map[string]struct{}) {
 	for _, ep := range endpoints {
 		resolved, ok := network.CheckURL(ep.Link, baseResource)
 		if !ok {
@@ -105,21 +127,25 @@ func processDomain(cfg config.Config, baseResource string, endpoints []model.End
 		}
 
 		newEndpoints := parser.FindEndpoints(body, regex, mode == output.ModeHTML, filter, true)
-		render(mode, resolved, newEndpoints, builder)
+		report := output.ResourceReport{Resource: resolved, Endpoints: newEndpoints}
+		render(mode, report, builder)
+		if reports != nil {
+			*reports = append(*reports, report)
+		}
 
 		if len(newEndpoints) > 0 {
-			processDomain(cfg, resolved, newEndpoints, regex, filter, mode, builder, visited)
+			processDomain(cfg, resolved, newEndpoints, regex, filter, mode, builder, reports, visited)
 		}
 	}
 }
 
-func render(mode output.Mode, resource string, endpoints []model.Endpoint, builder *strings.Builder) {
+func render(mode output.Mode, report output.ResourceReport, builder *strings.Builder) {
 	if mode == output.ModeCLI {
-		output.PrintCLI(resource, endpoints)
+		output.PrintCLI(report)
 		return
 	}
 
-	output.AppendHTML(builder, resource, endpoints)
+	output.AppendHTML(builder, report)
 }
 
 func exitWithError(err error) {


### PR DESCRIPTION
## Summary
- add a `--raw` flag and supporting report metadata to export endpoints into a plaintext file
- collect per-resource results so CLI mode shows a summary and HTML mode can render richer sections
- refresh the HTML template with improved styling, copy buttons, and semantic highlights

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e233b4846c8329aaf9147d91045c96