### PR TITLE
Add endpoint line numbers to HTML report

### DIFF
--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -11,4 +11,5 @@ type Target struct {
 type Endpoint struct {
 	Link    string
 	Context string
+	Line    int
 }

--- a/internal/output/html.go
+++ b/internal/output/html.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -56,6 +57,12 @@ func AppendHTML(builder *strings.Builder, report ResourceReport) {
 		builder.WriteString("\" class=\"endpoint-link\" target=\"_blank\" rel=\"nofollow noopener noreferrer\">")
 		builder.WriteString(safeLink)
 		builder.WriteString("</a>")
+		if ep.Line > 0 {
+			builder.WriteString("\n                        <span class=\"endpoint-line\">Line ")
+			builder.WriteString(strconv.Itoa(ep.Line))
+			builder.WriteString("</span>")
+		}
+
 		builder.WriteString("\n                        <button type=\"button\" class=\"copy-button\" data-copy=\"")
 		builder.WriteString(safeLink)
 		builder.WriteString("\">Copy</button>")

--- a/internal/output/template.html
+++ b/internal/output/template.html
@@ -167,6 +167,11 @@
             text-decoration: underline;
         }
 
+        .endpoint-line {
+            color: #94a3b8;
+            font-size: 0.85rem;
+        }
+
         .copy-button {
             background: rgba(59, 130, 246, 0.25);
             color: #e2e8f0;

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -122,6 +122,7 @@ func FindEndpoints(content string, regex *regexp.Regexp, includeContext bool, fi
 		}
 
 		ep := model.Endpoint{Link: link}
+		ep.Line = lineNumber(processed, matchStart)
 		if includeContext {
 			ep.Context = extractContext(processed, matchStart, matchEnd, false)
 		}
@@ -129,6 +130,18 @@ func FindEndpoints(content string, regex *regexp.Regexp, includeContext bool, fi
 	}
 
 	return results
+}
+
+func lineNumber(content string, index int) int {
+	if index < 0 {
+		return 0
+	}
+
+	if index > len(content) {
+		index = len(content)
+	}
+
+	return strings.Count(content[:index], "\n") + 1
 }
 
 func extractContext(content string, matchStart, matchEnd int, includeDelimiter bool) string {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -29,6 +29,10 @@ func TestFindEndpointsWithContextAndFilter(t *testing.T) {
 	if !regexp.MustCompile(`script`).MatchString(ep.Context) {
 		t.Fatalf("expected context to contain surrounding code, got %q", ep.Context)
 	}
+
+	if ep.Line != 2 {
+		t.Fatalf("expected endpoint to be on line 2, got %d", ep.Line)
+	}
 }
 
 func TestFindEndpointsWithoutContext(t *testing.T) {
@@ -43,6 +47,10 @@ func TestFindEndpointsWithoutContext(t *testing.T) {
 
 	if endpoints[0].Context != "" {
 		t.Fatalf("expected context to be empty when includeContext is false")
+	}
+
+	if endpoints[0].Line != 1 {
+		t.Fatalf("expected endpoint to be on line 1, got %d", endpoints[0].Line)
 	}
 }
 


### PR DESCRIPTION
## Summary
- capture the source line for each discovered endpoint during parsing
- surface line numbers in the HTML report with matching styling
- extend parser tests to cover the new metadata

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e236d8303c8329aa52ca3a0049d3b4