### PR TITLE
Add configurable recursion depth limit for domain crawling

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/example/GoLinkfinderEVO/internal/config"
+	"github.com/example/GoLinkfinderEVO/internal/model"
+	"github.com/example/GoLinkfinderEVO/internal/output"
+	"github.com/example/GoLinkfinderEVO/internal/parser"
+)
+
+func TestProcessDomainHonorsMaxDepth(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu       sync.Mutex
+		requests = make(map[string]int)
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests[r.URL.Path]++
+		mu.Unlock()
+
+		switch r.URL.Path {
+		case "/level1.js":
+			fmt.Fprint(w, `var next = "/level2.js";`)
+		case "/level2.js":
+			fmt.Fprint(w, `var next = "/level3.js";`)
+		case "/level3.js":
+			fmt.Fprint(w, `console.log("too deep");`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := config.Config{Timeout: time.Second, MaxDepth: 2}
+	endpoints := []model.Endpoint{{Link: "/level1.js"}}
+	regex := parser.EndpointRegex()
+	visited := make(map[string]struct{})
+	var reports []output.ResourceReport
+	var builder strings.Builder
+
+	processDomain(cfg, server.URL+"/index.html", endpoints, regex, nil, output.ModeHTML, &builder, &reports, visited, cfg.MaxDepth)
+
+	if got := requests["/level1.js"]; got == 0 {
+		t.Fatalf("expected /level1.js to be fetched, got %d", got)
+	}
+	if got := requests["/level2.js"]; got == 0 {
+		t.Fatalf("expected /level2.js to be fetched, got %d", got)
+	}
+	if got := requests["/level3.js"]; got != 0 {
+		t.Fatalf("expected recursion to stop before /level3.js, got %d fetches", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add a --max-depth flag to configure the recursion depth limit
- pass depth tracking into processDomain and stop recursion when the limit is reached
- add a test that verifies recursion stops once the configured depth is exhausted

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e2386d3014832995264de681d37786