### PR TITLE
Add max-depth option for domain recursion

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,16 +13,17 @@ import (
 
 // Config contains runtime configuration provided via flags.
 type Config struct {
-	Domain  bool
-	Scope   string
-	Input   string
-	Output  string
-	Raw     string
-	Regex   string
-	Burp    bool
-	Cookies string
-	Timeout time.Duration
-	Workers int
+	Domain   bool
+	Scope    string
+	Input    string
+	Output   string
+	Raw      string
+	Regex    string
+	Burp     bool
+	Cookies  string
+	Timeout  time.Duration
+	Workers  int
+	MaxDepth int
 }
 
 // ParseFlags parses CLI flags into a Config value.
@@ -49,6 +50,7 @@ func ParseFlags() (Config, error) {
 		printOption(out, "cookies", "c", "string", "Include cookies when fetching authenticated JavaScript files.", "")
 		printOption(out, "timeout", "t", "duration", "Maximum time to wait for server responses (e.g. 10s, 1m).", cfg.Timeout.String())
 		printOption(out, "workers", "", "int", "Maximum number of concurrent fetch operations.", strconv.Itoa(cfg.Workers))
+		printOption(out, "max-depth", "", "int", "Maximum recursion depth when using --domain (0 means unlimited).", strconv.Itoa(cfg.MaxDepth))
 	}
 
 	flag.BoolVar(&cfg.Domain, "domain", false, "Recursively parse JavaScript resources discovered on the provided domain.")
@@ -79,6 +81,7 @@ func ParseFlags() (Config, error) {
 	registerDurationAlias("t", "timeout", &cfg.Timeout)
 
 	flag.IntVar(&cfg.Workers, "workers", cfg.Workers, "Maximum number of concurrent fetch operations.")
+	flag.IntVar(&cfg.MaxDepth, "max-depth", 0, "Maximum recursion depth when using --domain (0 means unlimited).")
 
 	flag.Parse()
 
@@ -88,6 +91,10 @@ func ParseFlags() (Config, error) {
 
 	if cfg.Workers < 1 {
 		return cfg, errors.New("--workers must be at least 1")
+	}
+
+	if cfg.MaxDepth < 0 {
+		return cfg, errors.New("--max-depth must be at least 0")
 	}
 
 	return cfg, nil

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/example/GoLinkfinderEVO/internal/config"
+	"github.com/example/GoLinkfinderEVO/internal/model"
+)
+
+func TestProcessDomainMaxDepth(t *testing.T) {
+	cfg := config.Config{MaxDepth: 1}
+	visited := newVisitedSet()
+
+	endpoints := []model.Endpoint{
+		{Link: "https://example.com/a.js"},
+		{Link: "https://example.com/b.js"},
+	}
+
+	var mu sync.Mutex
+	var tasks []resourceTask
+	enqueue := func(task resourceTask) {
+		mu.Lock()
+		defer mu.Unlock()
+		tasks = append(tasks, task)
+	}
+
+	processDomain(context.Background(), cfg, "https://example.com/index.js", endpoints, visited, enqueue, cfg.MaxDepth)
+
+	if len(tasks) != len(endpoints) {
+		t.Fatalf("expected %d tasks, got %d", len(endpoints), len(tasks))
+	}
+
+	for _, task := range tasks {
+		if task.depth != 0 {
+			t.Fatalf("expected depth 0 for enqueued task, got %d", task.depth)
+		}
+	}
+
+	var next []resourceTask
+	for _, task := range tasks {
+		deeperEndpoints := []model.Endpoint{{Link: task.target.URL + "-deeper.js"}}
+		processDomain(context.Background(), cfg, task.target.URL, deeperEndpoints, visited, func(task resourceTask) {
+			next = append(next, task)
+		}, task.depth)
+	}
+
+	if len(next) != 0 {
+		t.Fatalf("expected no tasks due to depth limit, got %d", len(next))
+	}
+}


### PR DESCRIPTION
## Summary
- add a `--max-depth` flag to configure recursion depth for domain crawling
- propagate depth tracking through `processDomain` to stop when the limit is reached and log when it happens
- cover the new behaviour with a unit test for `processDomain`

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e2517ae19c83299bad2190eb41f524