### PR TITLE
Add JSON output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Implementation of the original LinkFinder utility in Go.
 ## Usage
 
 ```bash
-go run . -i <target> [-o output.html] [--regex <filter>] [--domain] [--scope <domain>] [--cookies <cookie-string>] [--timeout <seconds>]
+go run . -i <target> [-o output.html] [--regex <filter>] [--domain] [--scope <domain>] [--cookies <cookie-string>] [--timeout <seconds>] [--json <file>]
 ```
 
-The tool now prints matches to stdout in raw format by default. Provide `-o <file.html>` if you want to save the HTML report instead, or `--raw <file>` to export a machine-friendly plaintext list. The program accepts the same kinds of inputs as the Python version, including URLs, local files, wildcards and Burp XML exports (`-b`).
+The tool now prints matches to stdout in raw format by default. Provide `-o <file.html>` if you want to save the HTML report instead, use `--raw <file>` to export a machine-friendly plaintext list, or `--json <file>` to write metadata and resources in JSON format. The program accepts the same kinds of inputs as the Python version, including URLs, local files, wildcards and Burp XML exports (`-b`).
 
 The HTML report template is now embedded within the binary, so you no longer need to keep `template.html` alongside the executable when running the tool.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	Input   string
 	Output  string
 	Raw     string
+	JSON    string
 	Regex   string
 	Burp    bool
 	Cookies string
@@ -37,6 +38,7 @@ func ParseFlags() (Config, error) {
 		printOption(out, "input", "i", "string", "URL, file or folder to analyse. For folders you can use wildcards (e.g. '/*.js').", "")
 		printOption(out, "output", "o", "string", "Save the HTML report to this path. Leave empty for CLI output.", "")
 		printOption(out, "raw", "", "string", "Write the extracted endpoints to a plaintext file.", "")
+		printOption(out, "json", "", "string", "Write the report metadata and resources to a JSON file.", "")
 		printOption(out, "regex", "r", "string", "Only report endpoints matching the provided regular expression (e.g. '^/api/').", "")
 		printOption(out, "burp", "b", "", "Treat the input as a Burp Suite XML export.", "")
 		printOption(out, "cookies", "c", "string", "Include cookies when fetching authenticated JavaScript files.", "")
@@ -57,6 +59,8 @@ func ParseFlags() (Config, error) {
 
 	flag.StringVar(&cfg.Raw, "raw", "", "Write the extracted endpoints to a plaintext file.")
 	registerStringAlias("raw-output", "raw", &cfg.Raw)
+
+	flag.StringVar(&cfg.JSON, "json", "", "Write the report metadata and resources to a JSON file.")
 
 	flag.StringVar(&cfg.Regex, "regex", "", "Only report endpoints matching the provided regular expression (e.g. '^/api/').")
 	registerStringAlias("r", "regex", &cfg.Regex)

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -1,0 +1,30 @@
+package output
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+type jsonPayload struct {
+	Meta      Metadata         `json:"meta"`
+	Resources []ResourceReport `json:"resources"`
+}
+
+// WriteJSON writes the discovered resources and metadata to a JSON file.
+func WriteJSON(path string, reports []ResourceReport, meta Metadata) error {
+	payload := jsonPayload{Meta: meta, Resources: reports}
+
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	if dir := filepath.Dir(path); dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil && !os.IsExist(err) {
+			return err
+		}
+	}
+
+	return os.WriteFile(path, data, 0o644)
+}

--- a/internal/output/json_test.go
+++ b/internal/output/json_test.go
@@ -1,0 +1,77 @@
+package output
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/example/GoLinkfinderEVO/internal/model"
+)
+
+func TestWriteJSON(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+
+	reports := []ResourceReport{
+		{
+			Resource: "https://example.com/app.js",
+			Endpoints: []model.Endpoint{
+				{
+					Link:    "/api/v1",
+					Context: "fetch('/api/v1')",
+					Line:    12,
+				},
+			},
+		},
+		{
+			Resource:  "https://example.com/other.js",
+			Endpoints: []model.Endpoint{},
+		},
+	}
+
+	meta := Metadata{
+		GeneratedAt:    time.Date(2024, 3, 1, 15, 4, 5, 0, time.UTC),
+		TotalResources: len(reports),
+		TotalEndpoints: TotalEndpoints(reports),
+	}
+
+	if err := WriteJSON(path, reports, meta); err != nil {
+		t.Fatalf("WriteJSON() error = %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read JSON output: %v", err)
+	}
+
+	const expected = `{
+  "meta": {
+    "GeneratedAt": "2024-03-01T15:04:05Z",
+    "TotalResources": 2,
+    "TotalEndpoints": 1
+  },
+  "resources": [
+    {
+      "Resource": "https://example.com/app.js",
+      "Endpoints": [
+        {
+          "Link": "/api/v1",
+          "Context": "fetch('/api/v1')",
+          "Line": 12
+        }
+      ]
+    },
+    {
+      "Resource": "https://example.com/other.js",
+      "Endpoints": []
+    }
+  ]
+}`
+
+	if string(data) != expected {
+		t.Fatalf("unexpected JSON output:\nexpected:\n%s\n\nactual:\n%s", expected, string(data))
+	}
+}

--- a/main.go
+++ b/main.go
@@ -74,6 +74,12 @@ func main() {
 		}
 	}
 
+	if cfg.JSON != "" {
+		if err := output.WriteJSON(cfg.JSON, reports, meta); err != nil {
+			exitWithError(fmt.Errorf("unable to write JSON output: %w", err))
+		}
+	}
+
 	if mode == output.ModeHTML {
 		if err := output.SaveHTML(htmlBuilder.String(), cfg.Output, meta); err != nil {
 			fmt.Fprintf(os.Stderr, "Output can't be saved in %s due to exception: %v\n", cfg.Output, err)


### PR DESCRIPTION
## Summary
- add a --json flag to capture the output path in configuration and document it in the README
- implement a JSON writer for metadata and resource reports and cover it with a unit test
- invoke the JSON writer from main alongside the existing raw output handler

## Testing
- GOPROXY=off go test ./internal/output -run TestWriteJSON -v


------
https://chatgpt.com/codex/tasks/task_e_68e238a20e208329a154adf4188f0acd