### PR TITLE
Add proxy and insecure HTTP client options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ Implementation of the original LinkFinder utility in Go.
 ## Usage
 
 ```bash
-go run . -i <target> [-o output.html] [--regex <filter>] [--domain] [--scope <domain>] [--cookies <cookie-string>] [--timeout <seconds>]
+go run . -i <target> [-o output.html] [--regex <filter>] [--domain] [--scope <domain>] [--cookies <cookie-string>] [--proxy <url>] [--insecure] [--timeout <seconds>]
 ```
 
 The tool now prints matches to stdout in raw format by default. Provide `-o <file.html>` if you want to save the HTML report instead, or `--raw <file>` to export a machine-friendly plaintext list. The program accepts the same kinds of inputs as the Python version, including URLs, local files, wildcards and Burp XML exports (`-b`).
+
+When working behind a proxy, pass `--proxy http://127.0.0.1:8080` (or the appropriate scheme and address) to forward all outbound requests through it. For targets that use self-signed certificates you can opt into skipping TLS verification with `--insecure`; this should only be used in trusted environments such as local testing setups.
 
 The HTML report template is now embedded within the binary, so you no longer need to keep `template.html` alongside the executable when running the tool.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,15 +12,17 @@ import (
 
 // Config contains runtime configuration provided via flags.
 type Config struct {
-	Domain  bool
-	Scope   string
-	Input   string
-	Output  string
-	Raw     string
-	Regex   string
-	Burp    bool
-	Cookies string
-	Timeout time.Duration
+	Domain   bool
+	Scope    string
+	Input    string
+	Output   string
+	Raw      string
+	Regex    string
+	Burp     bool
+	Cookies  string
+	Proxy    string
+	Insecure bool
+	Timeout  time.Duration
 }
 
 // ParseFlags parses CLI flags into a Config value.
@@ -40,6 +42,8 @@ func ParseFlags() (Config, error) {
 		printOption(out, "regex", "r", "string", "Only report endpoints matching the provided regular expression (e.g. '^/api/').", "")
 		printOption(out, "burp", "b", "", "Treat the input as a Burp Suite XML export.", "")
 		printOption(out, "cookies", "c", "string", "Include cookies when fetching authenticated JavaScript files.", "")
+		printOption(out, "proxy", "", "string", "Forward HTTP requests through the provided proxy (e.g. http://127.0.0.1:8080).", "")
+		printOption(out, "insecure", "", "", "Skip TLS certificate verification when fetching HTTPS resources.", "")
 		printOption(out, "timeout", "t", "duration", "Maximum time to wait for server responses (e.g. 10s, 1m).", cfg.Timeout.String())
 	}
 
@@ -66,6 +70,10 @@ func ParseFlags() (Config, error) {
 
 	flag.StringVar(&cfg.Cookies, "cookies", "", "Include cookies when fetching authenticated JavaScript files.")
 	registerStringAlias("c", "cookies", &cfg.Cookies)
+
+	flag.StringVar(&cfg.Proxy, "proxy", "", "Forward HTTP requests through the provided proxy (e.g. http://127.0.0.1:8080).")
+
+	flag.BoolVar(&cfg.Insecure, "insecure", false, "Skip TLS certificate verification when fetching HTTPS resources.")
 
 	flag.DurationVar(&cfg.Timeout, "timeout", cfg.Timeout, "Maximum time to wait for server responses (e.g. 10s, 1m).")
 	registerDurationAlias("t", "timeout", &cfg.Timeout)

--- a/internal/network/request_test.go
+++ b/internal/network/request_test.go
@@ -5,6 +5,7 @@ import (
 	"compress/zlib"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -12,6 +13,9 @@ import (
 )
 
 func TestFetchDeflate(t *testing.T) {
+	resetHTTPClient()
+	t.Cleanup(resetHTTPClient)
+
 	const payload = "compressed content"
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -35,6 +39,72 @@ func TestFetchDeflate(t *testing.T) {
 	content, err := Fetch(server.URL, cfg)
 	if err != nil {
 		t.Fatalf("Fetch returned error: %v", err)
+	}
+
+	if content != payload {
+		t.Fatalf("unexpected content: got %q want %q", content, payload)
+	}
+}
+
+func TestFetchWithProxy(t *testing.T) {
+	resetHTTPClient()
+	t.Cleanup(resetHTTPClient)
+
+	const payload = "proxied response"
+	const targetURL = "http://example.com/resource"
+
+	var proxied atomic.Bool
+
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxied.Store(true)
+
+		if got := r.URL.String(); got != targetURL {
+			t.Fatalf("unexpected upstream URL: got %q want %q", got, targetURL)
+		}
+
+		if _, err := w.Write([]byte(payload)); err != nil {
+			t.Fatalf("failed to write proxy response: %v", err)
+		}
+	}))
+	defer proxy.Close()
+
+	cfg := config.Config{Timeout: time.Second, Proxy: proxy.URL}
+	content, err := Fetch(targetURL, cfg)
+	if err != nil {
+		t.Fatalf("Fetch returned error: %v", err)
+	}
+
+	if content != payload {
+		t.Fatalf("unexpected content: got %q want %q", content, payload)
+	}
+
+	if !proxied.Load() {
+		t.Fatalf("expected request to be routed through the proxy")
+	}
+}
+
+func TestFetchInsecureTLS(t *testing.T) {
+	resetHTTPClient()
+	t.Cleanup(resetHTTPClient)
+
+	const payload = "secure content"
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write([]byte(payload)); err != nil {
+			t.Fatalf("failed to write TLS response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	strictCfg := config.Config{Timeout: time.Second}
+	if _, err := Fetch(server.URL, strictCfg); err == nil {
+		t.Fatalf("expected TLS verification error without --insecure")
+	}
+
+	insecureCfg := config.Config{Timeout: time.Second, Insecure: true}
+	content, err := Fetch(server.URL, insecureCfg)
+	if err != nil {
+		t.Fatalf("Fetch returned error with --insecure: %v", err)
 	}
 
 	if content != payload {


### PR DESCRIPTION
## Summary
- add `--proxy` and `--insecure` flags to the CLI configuration and usage text
- reuse a shared HTTP client that honors proxy and TLS verification settings
- document the new networking options and cover them with dedicated request tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e23886b8b8832994523b5ac2c56569