### PR TITLE
Add scope subdomain option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ This command crawls `https://target.com`, prints discovered endpoints to stdout,
 # Scan a local JavaScript bundle and filter for API paths only
 go run . -i ./static/app.js --regex api --raw api-endpoints.txt
 
-# Enumerate a target through Burp and output JSON for further scripting
-go run . -i https://scope.example --scope example --proxy http://127.0.0.1:8080 --json findings.json
+# Enumerate a target through Burp, include subdomains, and output JSON for further scripting
+go run . -i https://scope.example --scope example --scope-include-subdomains --proxy http://127.0.0.1:8080 --json findings.json
 
 # Import historical data from a Burp Suite XML export
 go run . -b ./traffic-export.xml --workers 20
@@ -86,6 +86,7 @@ go run . -b ./traffic-export.xml --workers 20
 | `--regex` | Apply an additional regex filter to matches. |
 | `--domain` | Restrict results to the input domain only. |
 | `--scope` | Supply a custom allow-list of domains. |
+| `--scope-include-subdomains` | Expand `--scope` matches to include subdomains of the provided domain. |
 | `--cookies` | Attach cookies to outbound requests. |
 | `--proxy` | Proxy all HTTP/S traffic via the given URL. |
 | `--insecure` | Skip TLS certificate verification (use with caution). |
@@ -104,6 +105,7 @@ Leverage Go's concurrency to adapt to target environments:
 
 - Chain GoLinkFinder EVO with tools like `gau`, `waybackurls`, or `katana` to build comprehensive target lists.
 - Use scope flags to keep findings relevant to bug bounty programs and avoid out-of-scope domains.
+- Combine `--scope` with `--scope-include-subdomains` when a program allows wildcard coverage beneath a base domain.
 - Export JSON and feed it into automation workflows or data lakes for long-term recon tracking.
 - Pair with visualization dashboards or Notion/Obsidian notes by saving HTML reports.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,19 +13,21 @@ import (
 
 // Config contains runtime configuration provided via flags.
 type Config struct {
-	Domain   bool
-	Scope    string
-	Input    string
-	Output   string
-	Raw      string
-	Regex    string
-	Burp     bool
-	Cookies  string
-	Proxy    string
-	Insecure bool
-	Timeout  time.Duration
-	Workers  int
-	MaxDepth int
+	Domain                 bool
+	Scope                  string
+	ScopeIncludeSubdomains bool
+	Input                  string
+	Output                 string
+	Raw                    string
+	JSON                   string
+	Regex                  string
+	Burp                   bool
+	Cookies                string
+	Proxy                  string
+	Insecure               bool
+	Timeout                time.Duration
+	Workers                int
+	MaxDepth               int
 }
 
 // ParseFlags parses CLI flags into a Config value.
@@ -44,6 +46,7 @@ func ParseFlags() (Config, error) {
 
 		printOption(out, "domain", "d", "", "Recursively parse JavaScript resources discovered on the provided domain.", "")
 		printOption(out, "scope", "s", "string", "Restrict recursive JavaScript fetching to the specified domain (e.g. example.com).", "")
+		printOption(out, "scope-include-subdomains", "", "", "When used with --scope, also allow subdomains of the provided domain.", "")
 		printOption(out, "input", "i", "string", "URL, file or folder to analyse. For folders you can use wildcards (e.g. '/*.js').", "")
 		printOption(out, "output", "o", "string", "Save the HTML report to this path. Leave empty for CLI output.", "")
 		printOption(out, "raw", "", "string", "Write the extracted endpoints to a plaintext file.", "")
@@ -63,6 +66,8 @@ func ParseFlags() (Config, error) {
 
 	flag.StringVar(&cfg.Scope, "scope", "", "Restrict recursive JavaScript fetching to the specified domain (e.g. example.com).")
 	registerStringAlias("s", "scope", &cfg.Scope)
+
+	flag.BoolVar(&cfg.ScopeIncludeSubdomains, "scope-include-subdomains", false, "When used with --scope, also allow subdomains of the provided domain.")
 
 	flag.StringVar(&cfg.Input, "input", "", "URL, file or folder to analyse. For folders you can use wildcards (e.g. '/*.js').")
 	registerStringAlias("i", "input", &cfg.Input)

--- a/internal/network/url.go
+++ b/internal/network/url.go
@@ -77,7 +77,8 @@ func CheckURL(raw, base string) (string, bool) {
 
 // WithinScope reports whether the provided resource URL belongs to the supplied scope domain.
 // The scope can be provided with or without a scheme (e.g. "https://example.com" or "example.com").
-func WithinScope(resource, scope string) bool {
+// When includeSubdomains is true, subdomains of the provided scope are also considered in-scope.
+func WithinScope(resource, scope string, includeSubdomains bool) bool {
 	if scope == "" {
 		return true
 	}
@@ -105,5 +106,16 @@ func WithinScope(resource, scope string) bool {
 		return false
 	}
 
-	return strings.EqualFold(resourceHost, scopeHost)
+	resourceHost = strings.ToLower(resourceHost)
+	scopeHost = strings.ToLower(scopeHost)
+
+	if !includeSubdomains {
+		return resourceHost == scopeHost
+	}
+
+	if resourceHost == scopeHost {
+		return true
+	}
+
+	return strings.HasSuffix(resourceHost, "."+scopeHost)
 }

--- a/internal/network/url_test.go
+++ b/internal/network/url_test.go
@@ -73,43 +73,77 @@ func TestWithinScope(t *testing.T) {
 		name     string
 		resource string
 		scope    string
+		include  bool
 		want     bool
 	}{
 		{
 			name:     "matching host with scheme",
 			resource: "https://static.example.com/app.js",
 			scope:    "https://static.example.com",
+			include:  false,
 			want:     true,
 		},
 		{
 			name:     "matching host without scope scheme",
 			resource: "https://example.com/app.js",
 			scope:    "example.com",
+			include:  false,
 			want:     true,
 		},
 		{
 			name:     "different host",
 			resource: "https://cdn.example.com/app.js",
 			scope:    "example.com",
+			include:  false,
 			want:     false,
 		},
 		{
 			name:     "ignore port in resource",
 			resource: "https://example.com:8443/app.js",
 			scope:    "https://example.com",
+			include:  false,
 			want:     true,
 		},
 		{
 			name:     "invalid scope",
 			resource: "https://example.com/app.js",
 			scope:    "://",
+			include:  false,
+			want:     false,
+		},
+		{
+			name:     "include subdomain when enabled",
+			resource: "https://cdn.example.com/app.js",
+			scope:    "example.com",
+			include:  true,
+			want:     true,
+		},
+		{
+			name:     "include nested subdomain when enabled",
+			resource: "https://a.b.example.com/app.js",
+			scope:    "example.com",
+			include:  true,
+			want:     true,
+		},
+		{
+			name:     "subdomain disabled remains out of scope",
+			resource: "https://cdn.example.com/app.js",
+			scope:    "example.com",
+			include:  false,
+			want:     false,
+		},
+		{
+			name:     "suffix that is not a subdomain",
+			resource: "https://badexample.com/app.js",
+			scope:    "example.com",
+			include:  true,
 			want:     false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := WithinScope(tt.resource, tt.scope)
+			got := WithinScope(tt.resource, tt.scope, tt.include)
 			if got != tt.want {
 				t.Fatalf("expected %v, got %v", tt.want, got)
 			}

--- a/main.go
+++ b/main.go
@@ -215,7 +215,7 @@ func processDomain(ctx context.Context, cfg config.Config, baseResource string, 
 			continue
 		}
 
-		if cfg.Scope != "" && !network.WithinScope(resolved, cfg.Scope) {
+		if cfg.Scope != "" && !network.WithinScope(resolved, cfg.Scope, cfg.ScopeIncludeSubdomains) {
 			continue
 		}
 


### PR DESCRIPTION
## Summary
- add a `--scope-include-subdomains` flag to the CLI configuration and documentation
- extend scope checking to optionally include subdomains when crawling domains
- cover the new behavior with unit tests and update README guidance

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e258342088832987c1fd5f1ad4ee03