### PR TITLE
Fix JSON flag configuration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	Input    string
 	Output   string
 	Raw      string
+	JSON     string
 	Regex    string
 	Burp     bool
 	Cookies  string

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"flag"
+	"os"
+	"testing"
+)
+
+func TestParseFlagsJSON(t *testing.T) {
+	t.Parallel()
+
+	oldArgs := os.Args
+	t.Cleanup(func() {
+		os.Args = oldArgs
+	})
+
+	oldCommandLine := flag.CommandLine
+	t.Cleanup(func() {
+		flag.CommandLine = oldCommandLine
+	})
+
+	flag.CommandLine = flag.NewFlagSet(oldArgs[0], flag.ContinueOnError)
+
+	os.Args = []string{
+		oldArgs[0],
+		"-i", "https://example.com", "--json", "report.json",
+	}
+
+	cfg, err := ParseFlags()
+	if err != nil {
+		t.Fatalf("ParseFlags() returned error: %v", err)
+	}
+
+	if cfg.JSON != "report.json" {
+		t.Fatalf("expected JSON path to be %q, got %q", "report.json", cfg.JSON)
+	}
+}


### PR DESCRIPTION
## Summary
- add the missing JSON field to the CLI configuration structure so the --json flag works
- add a regression test that ensures ParseFlags captures the JSON path

## Testing
- go test ./internal/...


------
https://chatgpt.com/codex/tasks/task_e_68e25845bda88329bb95f9d5e46ac651