### PR TITLE
Add support for backtick-delimited endpoints in parser

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -12,9 +12,7 @@ import (
 	"github.com/example/GoLinkfinderEVO/internal/model"
 )
 
-const rawRegex = `
-
-  (?:"|')
+const endpointBody = `
 
   (
     ((?:[a-zA-Z]{1,10}://|//)
@@ -49,7 +47,17 @@ const rawRegex = `
 
   )
 
-  (?:"|')
+`
+
+const rawRegex = "" +
+	`
+  (?:
+    "` + endpointBody + `"
+    |
+    '` + endpointBody + `'
+    |
+    ` + "`" + endpointBody + "`" + `
+  )
 
 `
 const contextDelimiter = "\n"
@@ -105,7 +113,17 @@ func FindEndpoints(content string, regex *regexp.Regexp, includeContext bool, fi
 		if len(idx) < 4 {
 			continue
 		}
-		linkStart, linkEnd := idx[2], idx[3]
+
+		linkStart, linkEnd := -1, -1
+		for i := 2; i+1 < len(idx); i += 2 {
+			if idx[i] >= 0 && idx[i+1] >= 0 {
+				linkStart, linkEnd = idx[i], idx[i+1]
+				break
+			}
+		}
+		if linkStart == -1 || linkEnd == -1 {
+			continue
+		}
 		matchStart, matchEnd := idx[0], idx[1]
 		if linkStart < 0 || linkEnd < 0 || linkStart > len(processed) || linkEnd > len(processed) {
 			continue

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -54,6 +54,29 @@ func TestFindEndpointsWithoutContext(t *testing.T) {
 	}
 }
 
+func TestFindEndpointsWithBacktickDelimiters(t *testing.T) {
+	content := "const users = fetch(`/api/users`);\nconst posts = fetch('/api/posts');"
+	regex := EndpointRegex()
+
+	endpoints := FindEndpoints(content, regex, false, nil, false)
+
+	if len(endpoints) != 2 {
+		t.Fatalf("expected 2 endpoints, got %d", len(endpoints))
+	}
+
+	links := map[string]struct{}{}
+	for _, ep := range endpoints {
+		links[ep.Link] = struct{}{}
+	}
+
+	if _, ok := links["/api/users"]; !ok {
+		t.Fatalf("expected to find /api/users endpoint in results: %#v", links)
+	}
+	if _, ok := links["/api/posts"]; !ok {
+		t.Fatalf("expected to find /api/posts endpoint in results: %#v", links)
+	}
+}
+
 func TestHighlightContext(t *testing.T) {
 	context := `<script src="/js/app.js?version=1"></script>`
 	link := `/js/app.js?version=1`


### PR DESCRIPTION
## Summary
- extend the endpoint matching regex to handle both quote types and backtick delimiters
- adjust endpoint extraction to cope with multiple capture groups introduced by the new pattern
- add coverage for fetch calls that declare endpoints with backtick literals

## Testing
- go test ./internal/parser

------
https://chatgpt.com/codex/tasks/task_e_68e25ade1f708329bd60f580083cb74b