### PR TITLE
Expand parser endpoint extension coverage

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"fmt"
 	"html"
 	"regexp"
 	"sort"
@@ -12,7 +13,29 @@ import (
 	"github.com/example/GoLinkfinderEVO/internal/model"
 )
 
-const rawRegex = `
+// endpointFileExtensions enumerates the most common file extensions that should be captured
+// as potential endpoints. Keeping the list centralized makes it straightforward to extend or
+// document newly supported types.
+var endpointFileExtensions = []string{
+	"php",
+	"php5",
+	"asp",
+	"aspx",
+	"jsp",
+	"json",
+	"json5",
+	"action",
+	"html",
+	"js",
+	"txt",
+	"xml",
+	"config",
+	"ashx",
+}
+
+var endpointFileExtensionPattern = strings.Join(endpointFileExtensions, "|")
+
+const rawRegexTemplate = `
 
   (?:"|')
 
@@ -31,7 +54,7 @@ const rawRegex = `
 
     ([a-zA-Z0-9_\-/]{1,}/
     [a-zA-Z0-9_\-/.]{1,}
-    \.(?:[a-zA-Z]{1,4}|action)
+    \.(?:[a-zA-Z0-9-]{1,6}|%s)
     (?:[\?|#][^"|']{0,}|))
 
     |
@@ -43,8 +66,7 @@ const rawRegex = `
     |
 
     ([a-zA-Z0-9_\-]{1,}
-    \.(?:php|asp|aspx|jsp|json|
-         action|html|js|txt|xml)
+    \.(?:%s)
     (?:[\?|#][^"|']{0,}|))
 
   )
@@ -52,6 +74,9 @@ const rawRegex = `
   (?:"|')
 
 `
+
+var rawRegex = fmt.Sprintf(rawRegexTemplate, endpointFileExtensionPattern, endpointFileExtensionPattern)
+
 const contextDelimiter = "\n"
 
 var endpointRegex = regexp.MustCompile(compactPattern(rawRegex))

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -54,6 +54,41 @@ func TestFindEndpointsWithoutContext(t *testing.T) {
 	}
 }
 
+func TestFindEndpointsWithExtendedExtensions(t *testing.T) {
+	content := `const urls = ["/api/user.php5", "/static/data.json5?cache=1", "config.ashx", "settings.config"];`
+	regex := EndpointRegex()
+
+	endpoints := FindEndpoints(content, regex, false, nil, false)
+
+	expected := map[string]bool{
+		"/api/user.php5":             false,
+		"/static/data.json5?cache=1": false,
+		"config.ashx":                false,
+		"settings.config":            false,
+	}
+
+	if len(endpoints) != len(expected) {
+		t.Fatalf("expected %d endpoints, got %d", len(expected), len(endpoints))
+	}
+
+	for _, ep := range endpoints {
+		seen, ok := expected[ep.Link]
+		if !ok {
+			t.Fatalf("unexpected endpoint %q", ep.Link)
+		}
+		if seen {
+			t.Fatalf("endpoint %q reported multiple times", ep.Link)
+		}
+		expected[ep.Link] = true
+	}
+
+	for link, seen := range expected {
+		if !seen {
+			t.Fatalf("expected to find endpoint %q", link)
+		}
+	}
+}
+
 func TestHighlightContext(t *testing.T) {
 	context := `<script src="/js/app.js?version=1"></script>`
 	link := `/js/app.js?version=1`


### PR DESCRIPTION
## Summary
- centralize the endpoint file extension list and expand the regex to support digits, hyphens, and longer suffixes
- ensure raw endpoint matching now covers extensions like .php5, .json5, .config, and .ashx
- add parser tests verifying the newly supported endpoint extensions

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e25afc92448329bf02b9940993f86a