### PR TITLE
Expand parser endpoint extension coverage

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"fmt"
 	"html"
 	"regexp"
 	"sort"
@@ -12,7 +13,30 @@ import (
 	"github.com/example/GoLinkfinderEVO/internal/model"
 )
 
-const endpointBody = `
+var (
+	commonFileExtensions = []string{
+		"action",
+		"php",
+		"php5",
+		"asp",
+		"aspx",
+		"ashx",
+		"jsp",
+		"json",
+		"json5",
+		"html",
+		"js",
+		"txt",
+		"xml",
+		"config",
+	}
+	endpointBody = buildEndpointBody(commonFileExtensions)
+	rawRegex     = buildRawRegex(endpointBody)
+)
+
+func buildEndpointBody(extensions []string) string {
+	specificPattern := strings.Join(extensions, "|")
+	return fmt.Sprintf(`
 
   (
     ((?:[a-zA-Z]{1,10}://|//)
@@ -29,7 +53,7 @@ const endpointBody = `
 
     ([a-zA-Z0-9_\-/]{1,}/
     [a-zA-Z0-9_\-/.]{1,}
-    \.(?:[a-zA-Z]{1,4}|action)
+    \.(?:[a-zA-Z0-9_-]{1,10}|%s)
     (?:[\?|#][^"|']{0,}|))
 
     |
@@ -41,16 +65,17 @@ const endpointBody = `
     |
 
     ([a-zA-Z0-9_\-]{1,}
-    \.(?:php|asp|aspx|jsp|json|
-         action|html|js|txt|xml)
+    \.(?:%s)
     (?:[\?|#][^"|']{0,}|))
 
   )
 
-`
+`, specificPattern, specificPattern)
+}
 
-const rawRegex = "" +
-	`
+func buildRawRegex(endpointBody string) string {
+	return "" +
+		`
   (?:
     "` + endpointBody + `"
     |
@@ -60,6 +85,8 @@ const rawRegex = "" +
   )
 
 `
+}
+
 const contextDelimiter = "\n"
 
 var endpointRegex = regexp.MustCompile(compactPattern(rawRegex))

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -112,3 +112,24 @@ func TestEndpointRegexMatchesHostnamesWithoutDots(t *testing.T) {
 		}
 	}
 }
+
+func TestEndpointRegexMatchesExtendedExtensions(t *testing.T) {
+	content := `"/api/handler.php5" '/assets/config.json5' "/configuration/app.config" "../services/process.ashx"`
+
+	endpoints := FindEndpoints(content, EndpointRegex(), false, nil, false)
+
+	expected := map[string]struct{}{
+		"/api/handler.php5":         {},
+		"/assets/config.json5":      {},
+		"/configuration/app.config": {},
+		"../services/process.ashx":  {},
+	}
+
+	for _, ep := range endpoints {
+		delete(expected, ep.Link)
+	}
+
+	if len(expected) != 0 {
+		t.Fatalf("expected endpoints for extended extensions to be matched, missing: %#v", expected)
+	}
+}


### PR DESCRIPTION
## Summary
- build the endpoint regex dynamically so extensions can include digits, hyphens, and longer names
- centralize the list of common file extensions to ease future maintenance
- add tests covering php5, json5, config, and ashx endpoints

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e25c43805883299ab3c0797df1cf7a