### PR TITLE
Expand endpoint regex extension support

### DIFF
--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -129,3 +129,32 @@ func TestEndpointRegexSupportsExtendedSchemes(t *testing.T) {
 		}
 	}
 }
+
+func TestEndpointRegexSupportsExtendedFileExtensions(t *testing.T) {
+	content := `"/api/status.php5" '/config/app.config' 
+"/static/app.json5" '/handler/process.ashx'`
+
+	endpoints := FindEndpoints(content, EndpointRegex(), false, nil, false)
+
+	if len(endpoints) != 4 {
+		t.Fatalf("expected 4 endpoints, got %d", len(endpoints))
+	}
+
+	expected := map[string]struct{}{
+		"/api/status.php5":      {},
+		"/config/app.config":    {},
+		"/static/app.json5":     {},
+		"/handler/process.ashx": {},
+	}
+
+	for _, ep := range endpoints {
+		if _, ok := expected[ep.Link]; !ok {
+			t.Fatalf("unexpected endpoint found: %q", ep.Link)
+		}
+		delete(expected, ep.Link)
+	}
+
+	if len(expected) != 0 {
+		t.Fatalf("expected endpoints were not all matched: %#v", expected)
+	}
+}


### PR DESCRIPTION
## Summary
- extend the endpoint regex to support longer file extensions with digits and hyphens
- centralize the list of specific extensions in a configurable slice for easier maintenance
- add parser tests that cover php5, json5, config, and ashx endpoints

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e25d5bfbb48329a013d8b98fbb54b2