### PR TITLE
Allow configuring multiple output formats simultaneously

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Or run directly with `go run .` if you prefer not to build a binary.
 ### Basic usage
 
 ```bash
-go run . -i https://target.com -o report.html
+go run . -i https://target.com --output html=report.html
 ```
 
 This command crawls `https://target.com`, prints discovered endpoints to stdout, and saves an interactive HTML report to `report.html`.
@@ -68,7 +68,10 @@ This command crawls `https://target.com`, prints discovered endpoints to stdout,
 go run . -i ./static/app.js --regex api --raw api-endpoints.txt
 
 # Enumerate a target through Burp, include subdomains, and output JSON for further scripting
-go run . -i https://scope.example --scope example --scope-include-subdomains --proxy http://127.0.0.1:8080 --json findings.json
+go run . -i https://scope.example --scope example --scope-include-subdomains --proxy http://127.0.0.1:8080 --output json=findings.json
+
+# Crawl a domain and emit CLI, HTML, and JSON outputs simultaneously
+go run . -i https://target.com --output cli,html=report.html,json=findings.json
 
 # Import historical data from a Burp Suite XML export
 go run . -b ./traffic-export.xml --workers 20
@@ -80,9 +83,9 @@ go run . -b ./traffic-export.xml --workers 20
 | ---- | ----------- |
 | `-i, --input` | URL, file, glob pattern, or directory to scan. |
 | `-b, --burp` | Parse Burp Suite XML exports as input. |
-| `-o` | Write an HTML report to the specified file. |
-| `--raw` | Export a newline-delimited list of matches. |
-| `--json` | Save metadata, responses, and matches as JSON. |
+| `-o, --output` | Configure outputs. Accepts values like `cli`, `html=report.html`, `json=findings.json`, or `raw=endpoints.txt`. Repeat or comma-separate to combine formats. |
+| `--raw` | Alias for `--output raw=<file>`. |
+| `--json` | Alias for `--output json=<file>`. |
 | `--regex` | Apply an additional regex filter to matches. |
 | `--domain` | Restrict results to the input domain only. |
 | `--scope` | Supply a custom allow-list of domains. |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,26 +8,65 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 )
 
 // Config contains runtime configuration provided via flags.
 type Config struct {
-	Domain   bool
-	Scope    string
-	Input    string
-	Output   string
-	Raw      string
-	JSON     string
-	Regex    string
-	Burp     bool
-	Cookies  string
-	Proxy    string
-	Insecure bool
-	Timeout  time.Duration
-	Workers  int
-	MaxDepth int
+	Domain                 bool
+	Scope                  string
+	Input                  string
+	Regex                  string
+	Burp                   bool
+	Cookies                string
+	Proxy                  string
+	Insecure               bool
+	Timeout                time.Duration
+	Workers                int
+	MaxDepth               int
 	ScopeIncludeSubdomains bool
+	Outputs                []OutputTarget
+}
+
+// OutputFormat represents a supported output channel.
+type OutputFormat int
+
+const (
+	OutputCLI OutputFormat = iota
+	OutputHTML
+	OutputJSON
+	OutputRaw
+)
+
+func (f OutputFormat) String() string {
+	switch f {
+	case OutputCLI:
+		return "cli"
+	case OutputHTML:
+		return "html"
+	case OutputJSON:
+		return "json"
+	case OutputRaw:
+		return "raw"
+	default:
+		return "unknown"
+	}
+}
+
+func (f OutputFormat) requiresPath() bool {
+	switch f {
+	case OutputHTML, OutputJSON, OutputRaw:
+		return true
+	default:
+		return false
+	}
+}
+
+// OutputTarget represents a configured output destination.
+type OutputTarget struct {
+	Format OutputFormat
+	Path   string
 }
 
 // ParseFlags parses CLI flags into a Config value.
@@ -48,9 +87,7 @@ func ParseFlags() (Config, error) {
 		printOption(out, "scope", "s", "string", "Restrict recursive JavaScript fetching to the specified domain (e.g. example.com).", "")
 		printOption(out, "scope-include-subdomains", "", "", "When used with --scope, also allow subdomains of the provided domain.", "")
 		printOption(out, "input", "i", "string", "URL, file or folder to analyse. For folders you can use wildcards (e.g. '/*.js').", "")
-		printOption(out, "output", "o", "string", "Save the HTML report to this path. Leave empty for CLI output.", "")
-		printOption(out, "raw", "", "string", "Write the extracted endpoints to a plaintext file.", "")
-		printOption(out, "json", "", "string", "Write the report metadata and resources to a JSON file.", "")
+		printOption(out, "output", "o", "string", "Configure one or more outputs (e.g. 'cli', 'html=report.html'). May be repeated or comma separated.", "cli")
 		printOption(out, "regex", "r", "string", "Only report endpoints matching the provided regular expression (e.g. '^/api/').", "")
 		printOption(out, "burp", "b", "", "Treat the input as a Burp Suite XML export.", "")
 		printOption(out, "cookies", "c", "string", "Include cookies when fetching authenticated JavaScript files.", "")
@@ -72,13 +109,14 @@ func ParseFlags() (Config, error) {
 	flag.StringVar(&cfg.Input, "input", "", "URL, file or folder to analyse. For folders you can use wildcards (e.g. '/*.js').")
 	registerStringAlias("i", "input", &cfg.Input)
 
-	flag.StringVar(&cfg.Output, "output", "", "Save the HTML report to this path. Leave empty for CLI output.")
-	registerStringAlias("o", "output", &cfg.Output)
+	collector := newOutputCollector(&cfg.Outputs)
+	flag.Var(collector, "output", "Configure one or more outputs (e.g. cli, html=report.html). May be repeated or comma separated.")
+	flag.Var(collector, "o", "Alias for --output.")
 
-	flag.StringVar(&cfg.Raw, "raw", "", "Write the extracted endpoints to a plaintext file.")
-	registerStringAlias("raw-output", "raw", &cfg.Raw)
+	flag.Var(newOutputAlias(collector, OutputRaw), "raw", "Write the extracted endpoints to a plaintext file.")
+	flag.Var(newOutputAlias(collector, OutputRaw), "raw-output", "Alias for --raw.")
 
-	flag.StringVar(&cfg.JSON, "json", "", "Write the report metadata and resources to a JSON file.")
+	flag.Var(newOutputAlias(collector, OutputJSON), "json", "Write the report metadata and resources to a JSON file.")
 
 	flag.StringVar(&cfg.Regex, "regex", "", "Only report endpoints matching the provided regular expression (e.g. '^/api/').")
 	registerStringAlias("r", "regex", &cfg.Regex)
@@ -100,6 +138,10 @@ func ParseFlags() (Config, error) {
 	flag.IntVar(&cfg.MaxDepth, "max-depth", 0, "Maximum recursion depth when using --domain (0 means unlimited).")
 
 	flag.Parse()
+
+	if !collector.has(OutputCLI) {
+		_ = collector.add(OutputCLI, "")
+	}
 
 	if cfg.Input == "" {
 		return cfg, errors.New("-i/--input is required")
@@ -217,4 +259,180 @@ func (d *durationAlias) String() string {
 		return ""
 	}
 	return d.target.String()
+}
+
+type outputCollector struct {
+	targets  *[]OutputTarget
+	selected map[OutputFormat]string
+}
+
+func newOutputCollector(targets *[]OutputTarget) *outputCollector {
+	return &outputCollector{targets: targets, selected: make(map[OutputFormat]string)}
+}
+
+func (o *outputCollector) Set(value string) error {
+	if value == "" {
+		return errors.New("output flag requires a value")
+	}
+
+	entries := strings.Split(value, ",")
+	for _, entry := range entries {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+
+		format, path, err := parseOutputEntry(entry)
+		if err != nil {
+			return err
+		}
+
+		if err := o.add(format, path); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (o *outputCollector) String() string {
+	if o == nil || o.targets == nil {
+		return ""
+	}
+
+	parts := make([]string, 0, len(*o.targets))
+	for _, target := range *o.targets {
+		parts = append(parts, formatOutputValue(target))
+	}
+
+	return strings.Join(parts, ",")
+}
+
+func (o *outputCollector) add(format OutputFormat, path string) error {
+	if o == nil {
+		return errors.New("output collector not initialised")
+	}
+
+	if _, exists := o.selected[format]; exists {
+		return fmt.Errorf("output %s already specified", format.String())
+	}
+
+	if format.requiresPath() && path == "" {
+		return fmt.Errorf("output %s requires a file path", format.String())
+	}
+
+	if !format.requiresPath() && path != "" {
+		return fmt.Errorf("output %s does not accept a file path", format.String())
+	}
+
+	*o.targets = append(*o.targets, OutputTarget{Format: format, Path: path})
+	o.selected[format] = path
+	return nil
+}
+
+func (o *outputCollector) has(format OutputFormat) bool {
+	if o == nil {
+		return false
+	}
+	_, ok := o.selected[format]
+	return ok
+}
+
+func (o *outputCollector) pathFor(format OutputFormat) string {
+	if o == nil {
+		return ""
+	}
+	return o.selected[format]
+}
+
+func formatOutputValue(target OutputTarget) string {
+	switch target.Format {
+	case OutputCLI:
+		return target.Format.String()
+	default:
+		return fmt.Sprintf("%s=%s", target.Format.String(), target.Path)
+	}
+}
+
+func parseOutputEntry(entry string) (OutputFormat, string, error) {
+	var formatStr, path string
+
+	if idx := strings.IndexAny(entry, "=:"); idx != -1 {
+		formatStr = strings.ToLower(strings.TrimSpace(entry[:idx]))
+		path = strings.TrimSpace(entry[idx+1:])
+	} else {
+		lowered := strings.ToLower(strings.TrimSpace(entry))
+		switch lowered {
+		case OutputCLI.String(), OutputHTML.String(), OutputJSON.String(), OutputRaw.String():
+			formatStr = lowered
+		default:
+			formatStr = OutputHTML.String()
+			path = entry
+		}
+	}
+
+	format, err := parseOutputFormat(formatStr)
+	if err != nil {
+		return 0, "", err
+	}
+
+	if format.requiresPath() && path == "" {
+		return 0, "", fmt.Errorf("output %s requires a file path", format.String())
+	}
+
+	if !format.requiresPath() && path != "" {
+		return 0, "", fmt.Errorf("output %s does not accept a file path", format.String())
+	}
+
+	return format, path, nil
+}
+
+func parseOutputFormat(value string) (OutputFormat, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case OutputCLI.String():
+		return OutputCLI, nil
+	case OutputHTML.String():
+		return OutputHTML, nil
+	case OutputJSON.String():
+		return OutputJSON, nil
+	case OutputRaw.String():
+		return OutputRaw, nil
+	default:
+		if value == "" {
+			return OutputHTML, nil
+		}
+		return 0, fmt.Errorf("unsupported output format %q", value)
+	}
+}
+
+type outputAlias struct {
+	collector *outputCollector
+	format    OutputFormat
+}
+
+func newOutputAlias(collector *outputCollector, format OutputFormat) flag.Value {
+	return &outputAlias{collector: collector, format: format}
+}
+
+func (a *outputAlias) Set(value string) error {
+	if a.collector == nil {
+		return errors.New("output alias not initialised")
+	}
+
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		if a.format.requiresPath() {
+			return fmt.Errorf("output %s requires a file path", a.format.String())
+		}
+		return a.collector.add(a.format, "")
+	}
+
+	return a.collector.add(a.format, trimmed)
+}
+
+func (a *outputAlias) String() string {
+	if a.collector == nil {
+		return ""
+	}
+	return a.collector.pathFor(a.format)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -31,7 +31,25 @@ func TestParseFlagsJSON(t *testing.T) {
 		t.Fatalf("ParseFlags() returned error: %v", err)
 	}
 
-	if cfg.JSON != "report.json" {
-		t.Fatalf("expected JSON path to be %q, got %q", "report.json", cfg.JSON)
+	jsonTarget, ok := findOutput(cfg.Outputs, OutputJSON)
+	if !ok {
+		t.Fatalf("expected JSON output to be configured")
 	}
+
+	if jsonTarget.Path != "report.json" {
+		t.Fatalf("expected JSON path to be %q, got %q", "report.json", jsonTarget.Path)
+	}
+
+	if _, ok := findOutput(cfg.Outputs, OutputCLI); !ok {
+		t.Fatalf("expected CLI output to be configured by default")
+	}
+}
+
+func findOutput(outputs []OutputTarget, format OutputFormat) (OutputTarget, bool) {
+	for _, target := range outputs {
+		if target.Format == format {
+			return target, true
+		}
+	}
+	return OutputTarget{}, false
 }

--- a/internal/output/mode.go
+++ b/internal/output/mode.go
@@ -1,11 +1,16 @@
 package output
 
 // Mode defines how results are presented.
-type Mode int
+type Mode uint8
 
 const (
 	// ModeCLI prints endpoints to stdout.
-	ModeCLI Mode = iota
+	ModeCLI Mode = 1 << iota
 	// ModeHTML renders endpoints into an HTML report.
 	ModeHTML
 )
+
+// Includes reports whether the provided mode is enabled.
+func (m Mode) Includes(target Mode) bool {
+	return m&target != 0
+}


### PR DESCRIPTION
## Summary
- add a unified `--output` flag that accepts multiple targets (cli, html, json, raw)
- update runtime rendering to support concurrent CLI, HTML, JSON, and raw outputs
- refresh documentation and tests for the new output configuration semantics

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e26e3c4aa483298ddf2af5769df574