### PR TITLE
Add tests for scope include subdomains flag when scope uses scheme

### DIFF
--- a/internal/network/url_test.go
+++ b/internal/network/url_test.go
@@ -119,6 +119,13 @@ func TestWithinScope(t *testing.T) {
 			want:     true,
 		},
 		{
+			name:     "include subdomain when scope has scheme",
+			resource: "https://cdn.example.com/app.js",
+			scope:    "https://example.com/",
+			include:  true,
+			want:     true,
+		},
+		{
 			name:     "include nested subdomain when enabled",
 			resource: "https://a.b.example.com/app.js",
 			scope:    "example.com",
@@ -129,6 +136,13 @@ func TestWithinScope(t *testing.T) {
 			name:     "subdomain disabled remains out of scope",
 			resource: "https://cdn.example.com/app.js",
 			scope:    "example.com",
+			include:  false,
+			want:     false,
+		},
+		{
+			name:     "subdomain disabled when scope has scheme",
+			resource: "https://cdn.example.com/app.js",
+			scope:    "https://example.com/",
 			include:  false,
 			want:     false,
 		},

--- a/main_test.go
+++ b/main_test.go
@@ -85,6 +85,16 @@ func TestProcessDomainScopeFiltering(t *testing.T) {
 				"https://cdn.example.com/bundle.js",
 			},
 		},
+		{
+			name:    "include subdomains with scheme",
+			scope:   "https://example.com/",
+			include: true,
+			want: []string{
+				"https://example.com/static/app.js",
+				"https://example.com/local.js",
+				"https://cdn.example.com/bundle.js",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- add coverage ensuring WithinScope accepts subdomains when the scope includes a scheme and trailing slash
- extend processDomain tests to confirm subdomain crawling works when scope-include-subdomains is enabled with scheme-qualified scopes

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e26e8952908329b4eaf74bd4ed4943