### PR TITLE
Prevent worker deadlock when enqueueing domain crawl tasks

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,9 +96,20 @@ func main() {
 		taskWg.Add(1)
 		select {
 		case tasks <- task:
+			return
 		case <-ctx.Done():
 			taskWg.Done()
+			return
+		default:
 		}
+
+		go func() {
+			select {
+			case tasks <- task:
+			case <-ctx.Done():
+				taskWg.Done()
+			}
+		}()
 	}
 
 	for i := 0; i < cfg.Workers; i++ {


### PR DESCRIPTION
## Summary
- avoid blocking workers when enqueueing crawl tasks by falling back to an asynchronous send when the worker queue is full

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e2c20171408329a59d22d44241706e