### PR TITLE
Handle HTTP timeouts gracefully

### DIFF
--- a/main.go
+++ b/main.go
@@ -128,6 +128,12 @@ func main() {
 
 				content, err := resolveContent(task.target, cfg)
 				if err != nil {
+					if network.IsTimeoutError(err) {
+						fmt.Printf("Request timed out for: %s\n", task.target.URL)
+						taskWg.Done()
+						continue
+					}
+
 					if task.fromDomain {
 						fmt.Printf("Invalid input defined or SSL error for: %s\n", task.target.URL)
 						taskWg.Done()


### PR DESCRIPTION
## Summary
- treat request timeouts as non-fatal so scans continue when a resource is slow to respond
- add a helper to detect timeout errors from the HTTP client
- add unit coverage for the timeout detection helper

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e2d8af2dd88329bced37ec3377bfc6