### PR TITLE
Align transport timeouts with configured request limit

### DIFF
--- a/internal/network/request.go
+++ b/internal/network/request.go
@@ -66,6 +66,11 @@ func buildTransport(cfg config.Config) (*http.Transport, error) {
 
 	transport := base.Clone()
 
+	if cfg.Timeout > 0 {
+		transport.TLSHandshakeTimeout = cfg.Timeout
+		transport.ResponseHeaderTimeout = cfg.Timeout
+	}
+
 	if cfg.Proxy != "" {
 		proxyURL, err := url.Parse(cfg.Proxy)
 		if err != nil {

--- a/internal/network/request_test.go
+++ b/internal/network/request_test.go
@@ -147,6 +147,45 @@ func TestFetchConcurrentRequests(t *testing.T) {
 	}
 }
 
+func TestBuildTransportRespectsTimeout(t *testing.T) {
+	cfg := config.Config{Timeout: 30 * time.Second}
+
+	transport, err := buildTransport(cfg)
+	if err != nil {
+		t.Fatalf("buildTransport returned error: %v", err)
+	}
+
+	if got, want := transport.TLSHandshakeTimeout, cfg.Timeout; got != want {
+		t.Fatalf("TLSHandshakeTimeout = %v, want %v", got, want)
+	}
+
+	if got, want := transport.ResponseHeaderTimeout, cfg.Timeout; got != want {
+		t.Fatalf("ResponseHeaderTimeout = %v, want %v", got, want)
+	}
+}
+
+func TestBuildTransportZeroTimeout(t *testing.T) {
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		t.Skip("default transport is not *http.Transport")
+	}
+
+	cfg := config.Config{Timeout: 0}
+
+	transport, err := buildTransport(cfg)
+	if err != nil {
+		t.Fatalf("buildTransport returned error: %v", err)
+	}
+
+	if transport.TLSHandshakeTimeout != base.TLSHandshakeTimeout {
+		t.Fatalf("TLSHandshakeTimeout = %v, want %v", transport.TLSHandshakeTimeout, base.TLSHandshakeTimeout)
+	}
+
+	if transport.ResponseHeaderTimeout != base.ResponseHeaderTimeout {
+		t.Fatalf("ResponseHeaderTimeout = %v, want %v", transport.ResponseHeaderTimeout, base.ResponseHeaderTimeout)
+	}
+}
+
 func TestIsTimeoutError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- ensure the shared HTTP transport inherits the configured timeout for TLS handshakes and response headers to prevent premature deadline exceeded errors
- cover the new behaviour with tests for both non-zero and zero timeout configurations

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e2da4440a08329be549ed81b8f40d0