### PR TITLE
Handle HTTP client timeout error strings

### DIFF
--- a/internal/network/request.go
+++ b/internal/network/request.go
@@ -237,5 +237,16 @@ func IsTimeoutError(err error) bool {
 		return true
 	}
 
+	// Some timeout errors (for example http.Client when waiting for response
+	// headers) wrap the underlying context deadline error but only expose a
+	// descriptive message like "Client.Timeout exceeded while awaiting
+	// headers". In some cases this string can reach the caller without the
+	// wrapped error being detectable by the checks above. As a final
+	// fallback, detect this message to make sure these timeouts are treated
+	// as recoverable conditions.
+	if strings.Contains(err.Error(), "Client.Timeout exceeded") {
+		return true
+	}
+
 	return false
 }

--- a/internal/network/request_test.go
+++ b/internal/network/request_test.go
@@ -202,6 +202,7 @@ func TestIsTimeoutError(t *testing.T) {
 		{name: "os timeout", err: os.ErrDeadlineExceeded, want: true},
 		{name: "net timeout", err: errTimeout, want: true},
 		{name: "url error timeout", err: errURL, want: true},
+		{name: "client timeout string", err: errors.New("Get \"https://example.com\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)"), want: true},
 		{name: "non timeout", err: errors.New("boom"), want: false},
 	}
 


### PR DESCRIPTION
## Summary
- treat http.Client timeout messages as recoverable timeouts so execution continues
- cover the new fallback with an IsTimeoutError unit test case

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e2dc759738832996971fda17d0e323