### PR TITLE
Handle HTTP client timeout errors gracefully

### DIFF
--- a/internal/network/request.go
+++ b/internal/network/request.go
@@ -237,5 +237,10 @@ func IsTimeoutError(err error) bool {
 		return true
 	}
 
+	msg := err.Error()
+	if strings.Contains(msg, "Client.Timeout exceeded") || strings.Contains(msg, "context deadline exceeded") {
+		return true
+	}
+
 	return false
 }

--- a/internal/network/request_test.go
+++ b/internal/network/request_test.go
@@ -202,6 +202,7 @@ func TestIsTimeoutError(t *testing.T) {
 		{name: "os timeout", err: os.ErrDeadlineExceeded, want: true},
 		{name: "net timeout", err: errTimeout, want: true},
 		{name: "url error timeout", err: errURL, want: true},
+		{name: "client timeout string", err: errors.New("Get \"https://example.com\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)"), want: true},
 		{name: "non timeout", err: errors.New("boom"), want: false},
 	}
 


### PR DESCRIPTION
## Summary
- treat HTTP timeout errors surfaced only by their message string as timeouts so execution continues
- add a regression test covering the "Client.Timeout exceeded while awaiting headers" error string

## Testing
- GOPROXY=off go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e2dc759738832996971fda17d0e323