### PR TITLE
Add gf flag integration and reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Use GoLinkFinder EVO to supercharge your bug bounty methodology, automate URL di
 
 - 🔍 **Smart pattern matching** – Extract JavaScript endpoints, REST routes, AWS/GCP URLs, JWTs, keys, and more with customizable regex filters.
 - 📄 **Flexible outputs** – Stream matches to stdout, generate HTML reports for presentations, export plain text with `--raw`, or produce machine-readable JSON for integrations.
+- 🧰 **gf rule integration** – Run your favourite [tomnomnom/gf](https://github.com/tomnomnom/gf) patterns against discovered endpoints and export structured findings automatically.
 - 🌐 **Scope-aware crawling** – Constrain discovery to specific domains, respect scopes, and feed data from live URLs, local JS bundles, or Burp XML exports (`-b`).
 - 🔒 **Proxy & TLS control** – Route traffic through Burp/ZAP with `--proxy` or skip verification for lab environments via `--insecure`.
 - ⚙️ **Parallel workers** – Configure worker pools with `--workers` to balance speed, rate limits, and stealth.
@@ -77,6 +78,20 @@ go run . -i https://target.com --output cli,html=report.html,json=findings.json
 go run . -b ./traffic-export.xml --workers 20
 ```
 
+### gf integration
+
+Place your gf JSON definitions inside `~/.gf` (the same convention used by the original tool). Then pass either a comma-separated list of rule names or `all` to execute every JSON file:
+
+```bash
+# Run specific gf rules and generate gf.txt / gf.json with matches
+go run . -i https://target.com --gf jwt,urls
+
+# Execute every rule found inside ~/.gf
+go run . -i https://target.com --gf all
+```
+
+The generated `gf.txt` and `gf.json` files include the resource path, line number, matching evidence, and the rule responsible for each finding.
+
 ## Flags reference
 
 | Flag | Description |
@@ -95,6 +110,7 @@ go run . -b ./traffic-export.xml --workers 20
 | `--insecure` | Skip TLS certificate verification (use with caution). |
 | `--timeout` | Configure request timeout in seconds. |
 | `--workers` | Tune concurrency level. Defaults to logical CPU count. |
+| `--gf` | Execute gf patterns stored in `~/.gf`. Accepts comma-separated rule names or `all` to run every JSON file. Findings are saved to `gf.txt` and `gf.json`. |
 
 ## Performance tuning
 

--- a/internal/gf/gf.go
+++ b/internal/gf/gf.go
@@ -1,0 +1,206 @@
+package gf
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/lcalzada-xor/GoLinkfinderEVO/internal/output"
+)
+
+// Definition represents a gf rule loaded from disk.
+type Definition struct {
+	Name     string
+	Patterns []*regexp.Regexp
+}
+
+// Finding captures a gf match extracted from the reports.
+type Finding struct {
+	Resource string `json:"resource"`
+	Line     int    `json:"line"`
+	Evidence string `json:"evidence"`
+	Rule     string `json:"rule"`
+}
+
+// LoadDefinitions loads gf rule definitions from the ~/.gf directory.
+func LoadDefinitions(names []string, useAll bool) ([]Definition, error) {
+	dir, err := defaultDir()
+	if err != nil {
+		return nil, err
+	}
+
+	return loadDefinitionsFromDir(dir, names, useAll)
+}
+
+func defaultDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("unable to resolve user home directory: %w", err)
+	}
+
+	dir := filepath.Join(home, ".gf")
+	if _, err := os.Stat(dir); err != nil {
+		return "", fmt.Errorf("gf directory not found at %s: %w", dir, err)
+	}
+
+	return dir, nil
+}
+
+func loadDefinitionsFromDir(dir string, names []string, useAll bool) ([]Definition, error) {
+	var files []string
+	if useAll {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read gf directory: %w", err)
+		}
+
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			if !strings.HasSuffix(entry.Name(), ".json") {
+				continue
+			}
+			files = append(files, filepath.Join(dir, entry.Name()))
+		}
+
+		if len(files) == 0 {
+			return nil, errors.New("no gf rules found in ~/.gf")
+		}
+
+		sort.Strings(files)
+	} else {
+		if len(names) == 0 {
+			return nil, errors.New("no gf rule names provided")
+		}
+
+		for _, name := range names {
+			if name == "" {
+				continue
+			}
+
+			filename := name
+			if !strings.HasSuffix(filename, ".json") {
+				filename += ".json"
+			}
+
+			path := filepath.Join(dir, filename)
+			if _, err := os.Stat(path); err != nil {
+				return nil, fmt.Errorf("gf rule %s not found in %s", filename, dir)
+			}
+			files = append(files, path)
+		}
+
+		if len(files) == 0 {
+			return nil, errors.New("no gf rule names provided")
+		}
+	}
+
+	definitions := make([]Definition, 0, len(files))
+	for _, file := range files {
+		def, err := parseDefinition(file)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse %s: %w", filepath.Base(file), err)
+		}
+		definitions = append(definitions, def)
+	}
+
+	sort.Slice(definitions, func(i, j int) bool { return definitions[i].Name < definitions[j].Name })
+
+	return definitions, nil
+}
+
+type gfFile struct {
+	Pattern  string   `json:"pattern"`
+	Patterns []string `json:"patterns"`
+	Flags    string   `json:"flags"`
+}
+
+func parseDefinition(path string) (Definition, error) {
+	var def Definition
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return def, err
+	}
+
+	var file gfFile
+	if err := json.Unmarshal(content, &file); err != nil {
+		return def, err
+	}
+
+	var rawPatterns []string
+	if file.Pattern != "" {
+		rawPatterns = append(rawPatterns, file.Pattern)
+	}
+	rawPatterns = append(rawPatterns, file.Patterns...)
+
+	if len(rawPatterns) == 0 {
+		return def, errors.New("gf rule does not define any patterns")
+	}
+
+	ignoreCase := strings.Contains(strings.ToLower(file.Flags), "i")
+
+	compiled := make([]*regexp.Regexp, 0, len(rawPatterns))
+	for _, raw := range rawPatterns {
+		pattern := raw
+		if ignoreCase && !strings.HasPrefix(pattern, "(?i)") {
+			pattern = "(?i)" + pattern
+		}
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return def, fmt.Errorf("invalid pattern %q: %w", raw, err)
+		}
+		compiled = append(compiled, re)
+	}
+
+	name := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+
+	return Definition{Name: name, Patterns: compiled}, nil
+}
+
+// FindInReports runs all gf definitions against the collected reports and returns any matches found.
+func FindInReports(reports []output.ResourceReport, defs []Definition) []Finding {
+	findings := make([]Finding, 0)
+	if len(defs) == 0 {
+		return findings
+	}
+
+	for _, report := range reports {
+		for _, ep := range report.Endpoints {
+			for _, def := range defs {
+				for _, re := range def.Patterns {
+					matches := re.FindAllString(ep.Link, -1)
+					if matches == nil {
+						continue
+					}
+					for _, match := range matches {
+						findings = append(findings, Finding{
+							Resource: report.Resource,
+							Line:     ep.Line,
+							Evidence: match,
+							Rule:     def.Name,
+						})
+					}
+				}
+			}
+		}
+	}
+
+	return findings
+}
+
+// RuleNames extracts the names of the loaded definitions.
+func RuleNames(defs []Definition) []string {
+	names := make([]string, 0, len(defs))
+	for _, def := range defs {
+		names = append(names, def.Name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/gf/gf_test.go
+++ b/internal/gf/gf_test.go
@@ -1,0 +1,88 @@
+package gf
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/lcalzada-xor/GoLinkfinderEVO/internal/model"
+	"github.com/lcalzada-xor/GoLinkfinderEVO/internal/output"
+)
+
+func TestLoadDefinitionsFromDir(t *testing.T) {
+	dir := t.TempDir()
+
+	file := filepath.Join(dir, "token.json")
+	content := []byte(`{"pattern":"token","flags":"-i"}`)
+	if err := os.WriteFile(file, content, 0o644); err != nil {
+		t.Fatalf("failed to write gf definition: %v", err)
+	}
+
+	defs, err := loadDefinitionsFromDir(dir, []string{"token"}, false)
+	if err != nil {
+		t.Fatalf("loadDefinitionsFromDir returned error: %v", err)
+	}
+
+	if len(defs) != 1 {
+		t.Fatalf("expected 1 definition, got %d", len(defs))
+	}
+
+	if defs[0].Name != "token" {
+		t.Fatalf("expected rule name 'token', got %s", defs[0].Name)
+	}
+
+	if len(defs[0].Patterns) != 1 {
+		t.Fatalf("expected 1 compiled pattern, got %d", len(defs[0].Patterns))
+	}
+
+	if !defs[0].Patterns[0].MatchString("ACCESS_TOKEN") {
+		t.Fatalf("expected compiled pattern to honour case-insensitive flag")
+	}
+
+	defsAll, err := loadDefinitionsFromDir(dir, nil, true)
+	if err != nil {
+		t.Fatalf("loadDefinitionsFromDir (all) returned error: %v", err)
+	}
+
+	if len(defsAll) != 1 {
+		t.Fatalf("expected 1 definition when loading all, got %d", len(defsAll))
+	}
+}
+
+func TestFindInReports(t *testing.T) {
+	defs := []Definition{{
+		Name:     "token",
+		Patterns: []*regexp.Regexp{regexp.MustCompile("token")},
+	}}
+
+	reports := []output.ResourceReport{{
+		Resource: "app.js",
+		Endpoints: []model.Endpoint{{
+			Link: "/api/token/refresh",
+			Line: 42,
+		}},
+	}}
+
+	findings := FindInReports(reports, defs)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+
+	got := findings[0]
+	if got.Rule != "token" {
+		t.Fatalf("expected rule 'token', got %s", got.Rule)
+	}
+
+	if got.Resource != "app.js" {
+		t.Fatalf("expected resource 'app.js', got %s", got.Resource)
+	}
+
+	if got.Line != 42 {
+		t.Fatalf("expected line 42, got %d", got.Line)
+	}
+
+	if got.Evidence != "token" {
+		t.Fatalf("expected evidence 'token', got %s", got.Evidence)
+	}
+}

--- a/internal/gf/output.go
+++ b/internal/gf/output.go
@@ -1,0 +1,83 @@
+package gf
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	// TextFilename is the default filename for plaintext gf findings.
+	TextFilename = "gf.txt"
+	// JSONFilename is the default filename for JSON gf findings.
+	JSONFilename = "gf.json"
+)
+
+// WriteText creates a plaintext summary of gf findings.
+func WriteText(path string, generatedAt time.Time, rules []string, findings []Finding) error {
+	var buf bytes.Buffer
+
+	buf.WriteString("# GoLinkfinderEVO gf findings\n")
+	buf.WriteString(fmt.Sprintf("# Generated at: %s\n", generatedAt.Format(time.RFC3339)))
+	if len(rules) > 0 {
+		buf.WriteString(fmt.Sprintf("# Rules: %s\n", strings.Join(rules, ", ")))
+	} else {
+		buf.WriteString("# Rules: none\n")
+	}
+	buf.WriteString(fmt.Sprintf("# Total findings: %d\n\n", len(findings)))
+
+	if len(findings) == 0 {
+		buf.WriteString("# No gf findings were detected.\n")
+	} else {
+		for _, finding := range findings {
+			buf.WriteString("[Resource] ")
+			buf.WriteString(finding.Resource)
+			buf.WriteByte('\n')
+			buf.WriteString(fmt.Sprintf("Line: %d\n", finding.Line))
+			buf.WriteString(fmt.Sprintf("Rule: %s\n", finding.Rule))
+			buf.WriteString("Evidence: ")
+			buf.WriteString(finding.Evidence)
+			buf.WriteString("\n\n")
+		}
+	}
+
+	if dir := filepath.Dir(path); dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil && !os.IsExist(err) {
+			return err
+		}
+	}
+
+	return os.WriteFile(path, buf.Bytes(), 0o644)
+}
+
+type jsonReport struct {
+	GeneratedAt time.Time `json:"generated_at"`
+	Rules       []string  `json:"rules"`
+	Findings    []Finding `json:"findings"`
+}
+
+// WriteJSON serialises gf findings to JSON.
+func WriteJSON(path string, generatedAt time.Time, rules []string, findings []Finding) error {
+	report := jsonReport{
+		GeneratedAt: generatedAt,
+		Rules:       rules,
+		Findings:    findings,
+	}
+
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	if dir := filepath.Dir(path); dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil && !os.IsExist(err) {
+			return err
+		}
+	}
+
+	return os.WriteFile(path, data, 0o644)
+}


### PR DESCRIPTION
## Summary
- add a --gf flag that loads gf rule definitions from ~/.gf and runs them against discovered endpoints
- write gf findings to new gf.txt and gf.json reports with rule, resource, line and evidence metadata
- document the integration in the README and cover the new logic with unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e3ed45e5c88329ba5bbec820f76f57