### PR TITLE
Enhance gf findings with context and merged rules

### DIFF
--- a/internal/gf/gf_test.go
+++ b/internal/gf/gf_test.go
@@ -70,10 +70,6 @@ func TestFindInReports(t *testing.T) {
 	}
 
 	got := findings[0]
-	if got.Rule != "token" {
-		t.Fatalf("expected rule 'token', got %s", got.Rule)
-	}
-
 	if got.Resource != "app.js" {
 		t.Fatalf("expected resource 'app.js', got %s", got.Resource)
 	}
@@ -84,5 +80,80 @@ func TestFindInReports(t *testing.T) {
 
 	if got.Evidence != "token" {
 		t.Fatalf("expected evidence 'token', got %s", got.Evidence)
+	}
+
+	if len(got.Rules) != 1 || got.Rules[0] != "token" {
+		t.Fatalf("expected rules ['token'], got %v", got.Rules)
+	}
+
+	if got.Context != "" {
+		t.Fatalf("expected empty context, got %q", got.Context)
+	}
+}
+
+func TestFindInReportsMergesRulesAndContext(t *testing.T) {
+	defs := []Definition{
+		{
+			Name:     "token",
+			Patterns: []*regexp.Regexp{regexp.MustCompile("token")},
+		},
+		{
+			Name:     "api",
+			Patterns: []*regexp.Regexp{regexp.MustCompile("api")},
+		},
+	}
+
+	reports := []output.ResourceReport{{
+		Resource: "app.js",
+		Endpoints: []model.Endpoint{{
+			Link:    "/api/token/refresh",
+			Context: "fetch('/api/token/refresh')",
+			Line:    42,
+		}},
+	}}
+
+	findings := FindInReports(reports, defs)
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings (token and api), got %d", len(findings))
+	}
+
+	for _, finding := range findings {
+		if finding.Context == "" {
+			t.Fatalf("expected finding context to be populated")
+		}
+		if len(finding.Rules) != 1 {
+			t.Fatalf("expected each finding to have one rule, got %v", finding.Rules)
+		}
+	}
+
+	// Ensure that matches for identical evidence aggregate rules together.
+	defs = []Definition{
+		{
+			Name:     "token",
+			Patterns: []*regexp.Regexp{regexp.MustCompile("token")},
+		},
+		{
+			Name:     "token-alt",
+			Patterns: []*regexp.Regexp{regexp.MustCompile("token")},
+		},
+	}
+
+	findings = FindInReports(reports, defs)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding when evidence is shared, got %d", len(findings))
+	}
+
+	got := findings[0]
+	if len(got.Rules) != 2 {
+		t.Fatalf("expected 2 aggregated rules, got %v", got.Rules)
+	}
+
+	if got.Context == "" {
+		t.Fatalf("expected context to be kept when aggregating findings")
+	}
+
+	expectedEvidence := "token"
+	if got.Evidence != expectedEvidence {
+		t.Fatalf("expected evidence %q, got %q", expectedEvidence, got.Evidence)
 	}
 }

--- a/internal/gf/output.go
+++ b/internal/gf/output.go
@@ -38,10 +38,26 @@ func WriteText(path string, generatedAt time.Time, rules []string, findings []Fi
 			buf.WriteString(finding.Resource)
 			buf.WriteByte('\n')
 			buf.WriteString(fmt.Sprintf("Line: %d\n", finding.Line))
-			buf.WriteString(fmt.Sprintf("Rule: %s\n", finding.Rule))
+			if len(finding.Rules) > 0 {
+				buf.WriteString(fmt.Sprintf("Rules: %s\n", strings.Join(finding.Rules, ", ")))
+			} else {
+				buf.WriteString("Rules: none\n")
+			}
 			buf.WriteString("Evidence: ")
 			buf.WriteString(finding.Evidence)
-			buf.WriteString("\n\n")
+			buf.WriteByte('\n')
+
+			trimmed := strings.TrimSpace(finding.Context)
+			if trimmed != "" {
+				buf.WriteString("Context:\n")
+				for _, line := range strings.Split(trimmed, "\n") {
+					buf.WriteString("  ")
+					buf.WriteString(line)
+					buf.WriteByte('\n')
+				}
+			}
+
+			buf.WriteByte('\n')
 		}
 	}
 


### PR DESCRIPTION
## Summary
- include endpoint context and aggregated rule names in gf findings
- update gf text output to show context snippets for each finding
- extend gf tests to cover context extraction and rule merging

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e3f688c8188329b9c1da779598e21f