### PR TITLE
Allow configuring gf outputs via --output flag

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,8 @@ const (
 	OutputHTML
 	OutputJSON
 	OutputRaw
+	OutputGFText
+	OutputGFJSON
 )
 
 func (f OutputFormat) String() string {
@@ -51,6 +53,10 @@ func (f OutputFormat) String() string {
 		return "json"
 	case OutputRaw:
 		return "raw"
+	case OutputGFText:
+		return "gf.txt"
+	case OutputGFJSON:
+		return "gf.json"
 	default:
 		return "unknown"
 	}
@@ -58,7 +64,7 @@ func (f OutputFormat) String() string {
 
 func (f OutputFormat) requiresPath() bool {
 	switch f {
-	case OutputHTML, OutputJSON, OutputRaw:
+	case OutputHTML, OutputJSON, OutputRaw, OutputGFText, OutputGFJSON:
 		return true
 	default:
 		return false
@@ -89,7 +95,7 @@ func ParseFlags() (Config, error) {
 		printOption(out, "scope", "s", "string", "Restrict recursive JavaScript fetching to the specified domain (e.g. example.com).", "")
 		printOption(out, "scope-include-subdomains", "", "", "When used with --scope, also allow subdomains of the provided domain.", "")
 		printOption(out, "input", "i", "string", "URL, file or folder to analyse. For folders you can use wildcards (e.g. '/*.js').", "")
-		printOption(out, "output", "o", "string", "Configure one or more outputs (e.g. 'cli', 'html=report.html'). May be repeated or comma separated.", "cli")
+		printOption(out, "output", "o", "string", "Configure one or more outputs (e.g. 'cli', 'html=report.html', 'gf.txt=findings.txt'). May be repeated or comma separated.", "cli")
 		printOption(out, "regex", "r", "string", "Only report endpoints matching the provided regular expression (e.g. '^/api/').", "")
 		printOption(out, "burp", "b", "", "Treat the input as a Burp Suite XML export.", "")
 		printOption(out, "cookies", "c", "string", "Include cookies when fetching authenticated JavaScript files.", "")
@@ -429,6 +435,10 @@ func parseOutputFormat(value string) (OutputFormat, error) {
 		return OutputJSON, nil
 	case OutputRaw.String():
 		return OutputRaw, nil
+	case OutputGFText.String():
+		return OutputGFText, nil
+	case OutputGFJSON.String():
+		return OutputGFJSON, nil
 	default:
 		if value == "" {
 			return OutputHTML, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,8 +7,6 @@ import (
 )
 
 func TestParseFlagsJSON(t *testing.T) {
-	t.Parallel()
-
 	oldArgs := os.Args
 	t.Cleanup(func() {
 		os.Args = oldArgs
@@ -42,6 +40,49 @@ func TestParseFlagsJSON(t *testing.T) {
 
 	if _, ok := findOutput(cfg.Outputs, OutputCLI); !ok {
 		t.Fatalf("expected CLI output to be configured by default")
+	}
+}
+
+func TestParseFlagsGFOutputs(t *testing.T) {
+	oldArgs := os.Args
+	t.Cleanup(func() {
+		os.Args = oldArgs
+	})
+
+	oldCommandLine := flag.CommandLine
+	t.Cleanup(func() {
+		flag.CommandLine = oldCommandLine
+	})
+
+	flag.CommandLine = flag.NewFlagSet(oldArgs[0], flag.ContinueOnError)
+
+	os.Args = []string{
+		oldArgs[0],
+		"--output", "cli,gf.txt=findings.txt,gf.json=findings.json",
+		"-i", "https://example.com", "--gf", "all",
+	}
+
+	cfg, err := ParseFlags()
+	if err != nil {
+		t.Fatalf("ParseFlags() returned error: %v", err)
+	}
+
+	gfText, ok := findOutput(cfg.Outputs, OutputGFText)
+	if !ok {
+		t.Fatalf("expected gf text output to be configured")
+	}
+
+	if gfText.Path != "findings.txt" {
+		t.Fatalf("expected gf text path to be %q, got %q", "findings.txt", gfText.Path)
+	}
+
+	gfJSON, ok := findOutput(cfg.Outputs, OutputGFJSON)
+	if !ok {
+		t.Fatalf("expected gf JSON output to be configured")
+	}
+
+	if gfJSON.Path != "findings.json" {
+		t.Fatalf("expected gf JSON path to be %q, got %q", "findings.json", gfJSON.Path)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -25,10 +25,14 @@ func main() {
 		exitWithError(err)
 	}
 
-	var mode output.Mode
-	var htmlPath string
-	var jsonPath string
-	var rawPath string
+	var (
+		mode       output.Mode
+		htmlPath   string
+		jsonPath   string
+		rawPath    string
+		gfTextPath = gf.TextFilename
+		gfJSONPath = gf.JSONFilename
+	)
 
 	for _, target := range cfg.Outputs {
 		switch target.Format {
@@ -41,6 +45,10 @@ func main() {
 			jsonPath = target.Path
 		case config.OutputRaw:
 			rawPath = target.Path
+		case config.OutputGFText:
+			gfTextPath = target.Path
+		case config.OutputGFJSON:
+			gfJSONPath = target.Path
 		}
 	}
 
@@ -197,11 +205,11 @@ func main() {
 		findings := gf.FindInReports(reports, definitions)
 		rules := gf.RuleNames(definitions)
 
-		if err := gf.WriteText(gf.TextFilename, generatedAt, rules, findings); err != nil {
+		if err := gf.WriteText(gfTextPath, generatedAt, rules, findings); err != nil {
 			exitWithError(fmt.Errorf("unable to write gf text findings: %w", err))
 		}
 
-		if err := gf.WriteJSON(gf.JSONFilename, generatedAt, rules, findings); err != nil {
+		if err := gf.WriteJSON(gfJSONPath, generatedAt, rules, findings); err != nil {
 			exitWithError(fmt.Errorf("unable to write gf JSON findings: %w", err))
 		}
 	}


### PR DESCRIPTION
## Summary
- add dedicated gf.txt and gf.json output formats to the --output flag to allow custom destinations
- use configured gf output paths when writing findings while retaining the default filenames otherwise
- cover the new output formats with configuration flag tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e51376bfb883299b18662a05f60ae3